### PR TITLE
Fix cerebrum import password and table existence checks

### DIFF
--- a/dtools.5pk.src
+++ b/dtools.5pk.src
@@ -1733,7 +1733,7 @@ command.cerebrum = function(arg1, arg2, arg3=0, arg4=0)
 				r_ip = arg2
 				r_p = get_custom_object.HOME.loginport
 				r_pas = get_custom_object.HOME.pass
-				if r_pass == "password" or r_pas == "" then 
+				if r_pas == "password" or r_pas == "" then 
 					r_pas = user_input("@home server password (leave blank to abort)"+char(10)+":> ", 1) 
 					if r_pas.trim == "" then return("aborting...")
 					alt = user_input("Set "+r_pas+" as @home pass? [<b>Y</b>/n] ||: ",1,1).lower
@@ -1742,7 +1742,7 @@ command.cerebrum = function(arg1, arg2, arg3=0, arg4=0)
 				r_r = globals.shell.connect_service(r_ip, r_p, get_custom_object.HOME.user, r_pas)
 				if typeof(r_r) == "shell" then
 					infile = r_r.host_computer.File(get_custom_object.HOME.tp)
-					if typeof(infile) != file then 
+					if typeof(infile) != "file" then 
 						infile = r_r.host_computer.File(get_custom_object.HOME.t5)
 						if typeof(infile) != "file" then return colorWarning+"cerebrum: unable to locate tables/tp or tables/t5"+char(10)+"-- run <b>pwgen</b> on server or"+char(10)+"-- check gco.HOME.t5 or gco.HOME.tp"
 					end if


### PR DESCRIPTION
This ought to fix an issue that occurred in the most recent version a5d3d5808a3701afa2463d1bceb9a705fb0e829a. Attempting to import a database from the configured home server, it fails with an error:
```
$ cerebrum -i @home
Runtime Error: Undefined Identifier: 'r_pass' is unknown in this context [5hell.5pk line 6700]
```
Investigating `dtools`, it became apparent there was a typo in `r_pass`. A subsequent error pointed out that file was not defined in `typeof(infile) != file`. Looking two lines below, I figured that `file` was probably meant to be a string instead.

Having made these minor changes I'm able to use `cerebrum -i @home` succesfully.