### PR TITLE
Remove lambdas as commands support, update Glosure interpreter to match upstream

### DIFF
--- a/5hell.src
+++ b/5hell.src
@@ -407,48 +407,6 @@ command.shell = function(input=null,mute=null)
       end if
       //
       f = @command[cmdName]
-     // Support for Glosure's lambdas
-        if typeof(@f) == "lambda" then
-          readString = function(s)
-            return "'" + s + "'"
-          end function
-          readArray = function(array)
-            i = 0
-            while i < len(array)
-              elem = @array[i]
-              if @elem isa string then array[i] = readString(elem)
-              if @elem isa list then array[i] = readArray(elem)
-              i = i + 1
-            end while
-            return [ "array" ] + array
-          end function
-          readArgs = function(args)
-            i = 0
-            while i < len(@args)
-              arg = @args[i]
-              if @arg isa string then args[i] = readString(arg)
-              if @arg isa list then args[i] = readArray(arg)
-              i = i + 1
-            end while
-          end function
-          lambda = f
-          f = function(arg1, arg2, arg3, arg4)
-            args = [
-              @arg1,
-              @arg2,
-              @arg3,
-              @arg4,
-            ]
-            readArgs args
-            return command.glosure("eval", [
-              lambda,
-              @args[0],
-              @args[1],
-              @args[2],
-              @args[3],
-            ])
-          end function
-        end if
       if typeof(@f) != "function" then // san check #3
         print(colorOrange+"shell: use <b>cob get ["+f+"]</b> to retrieve element.")
         continue
@@ -592,3 +550,4 @@ end while
 ////end main////
 //////////end of do not edit section//////////////
 ///EOF///
+

--- a/contrib.5pk.src
+++ b/contrib.5pk.src
@@ -418,27 +418,60 @@ command.glosure = function(arg1, arg2=0, arg3=0, arg4=0)
             }
             __eval = @eval
             __env = @env
+            readString = function(s)
+                return "'" + s + "'"
+            end function
+            readArray = function(array)
+                i = 0
+                while i < len(array)
+                    elem = @array[i]
+                    if @elem isa string then array[i] = outer.readString(elem)
+                    if @elem isa list then array[i] = outer.readArray(elem)
+                    i = i + 1
+                end while
+                return [ "array" ] + array
+            end function
+            readArgs = function(args)
+                    i = 0
+                    while i < len(@args)
+                    arg = @args[i]
+                    if @arg isa string then args[i] = outer.readString(arg)
+                    if @arg isa list then args[i] = outer.readArray(arg)
+                    i = i + 1
+                end while
+            end function
             buildGlosure = function
                 __eval = @outer.__eval
                 __env = @outer.__env
                 lambda = @outer.lambda
+                readArgs = @outer.readArgs
                 glosure0 = function()
                     return __eval([lambda], __env)
                 end function
                 glosure1 = function(arg0)
-                    return __eval([lambda, @arg0], __env)
+                    args = [@arg0]
+                    outer.readArgs(args)
+                    return __eval([lambda, @args[0]], __env)
                 end function
                 glosure2 = function(arg0, arg1)
-                    return __eval([lambda, @arg0, @arg1], __env)
+                    args = [@arg0, @arg1]
+                    outer.readArgs(args)
+                    return __eval([lambda, @args[0], @args[1]], __env)
                 end function
                 glosure3 = function(arg0, arg1, arg2)
-                    return __eval([lambda, @arg0, @arg1, @arg2], __env)
+                    args = [@arg0, @arg1, @arg2]
+                    outer.readArgs(args)
+                    return __eval([lambda, @args[0], @args[1], @args[2]], __env)
                 end function
                 glosure4 = function(arg0, arg1, arg2, arg3)
-                    return __eval([lambda, @arg0, @arg1, @arg2, @arg3], __env)
+                    args = [@arg0, @arg1, @arg2, @arg3]
+                    outer.readArgs(args)
+                    return __eval([lambda, @args[0], @args[1], @args[2], @args[3]], __env)
                 end function
                 glosure5 = function(arg0, arg1, arg2, arg3, arg4)
-                    return __eval([lambda, @arg0, @arg1, @arg2, @arg3, @arg4], __env)
+                    args = [@arg0, @arg1, @arg2, @arg3, @arg4]
+                    outer.readArgs(args)
+                    return __eval([lambda, @args[0], @args[1], @args[2], @args[3], @args[4]], __env)
                 end function
                 if len(lambda.params) == 0 then return @glosure0
                 if len(lambda.params) == 1 then return @glosure1

--- a/contrib.5pk.src
+++ b/contrib.5pk.src
@@ -862,7 +862,7 @@ command.glosure = function(arg1, arg2=0, arg3=0, arg4=0)
   
     helpMsg = "Usage: glosure -- invoke Glosure REPL, type ;quit to quit.
   Usage: glosure [-e|exec] ""code""  -- execute Glosure code.
-  Glosure interpreter version: b9c9e07. For a more detailed guide read https://github.com/rocketorbit/Glosure/blob/main/Tutorial.md
+  Glosure interpreter version: 237f129. For a more detailed guide read https://github.com/rocketorbit/Glosure/blob/main/Tutorial.md
   <b>Warning: This command is a programming language! Your error may result in crash!</b>
   
   Short reference:
@@ -1536,3 +1536,4 @@ Modes:
   end if
   return output[:-1]
 end function
+

--- a/help.5pk.src
+++ b/help.5pk.src
@@ -515,48 +515,6 @@ command.help = function(arg1, arg2, arg3=0, arg4=0)
 		for cmd in command.indexes.sort
 			if cmd == "shell" or cmd == "help" or cmd == "__isa" or cmd == "classID" then continue
 			h = @command[cmd]
-			// Support for Glosure's lambdas
-			if typeof(@h) == "lambda" then
-				readString = function(s)
-					return "'" + s + "'"
-				end function
-				readArray = function(array)
-					i = 0
-					while i < len(array)
-						elem = @array[i]
-						if @elem isa string then array[i] = readString(elem)
-						if @elem isa list then array[i] = readArray(elem)
-						i = i + 1
-					end while
-					return [ "array" ] + array
-				end function
-				readArgs = function(args)
-					i = 0
-					while i < len(@args)
-						arg = @args[i]
-						if @arg isa string then args[i] = readString(arg)
-						if @arg isa list then args[i] = readArray(arg)
-						i = i + 1
-					end while
-				end function
-				lambda = h
-				h = function(arg1, arg2, arg3, arg4)
-					args = [
-						@arg1,
-						@arg2,
-						@arg3,
-						@arg4,
-					]
-					readArgs args
-					return command.glosure("eval", [
-						lambda,
-						@args[0],
-						@args[1],
-						@args[2],
-						@args[3],
-					])
-				end function
-			end if
 			c_buf.push(colorWhite+cmd+CT)
 			c_buf.push(h("help"))
 		end for


### PR DESCRIPTION
So uhmmm... 👉👈

It was a terrible idea! 😅

When someone hooks into an existing command, it's being replaced with lambda. The problem? Other parts of the code still think of this existing command as of an ordinary miniscript function, which results in crash if attempting to call a command like this...

This is exactly why nt has crashed with Marinette - because run which I've hooked was lambda 😓

Now though it won't happen - instead Marinette will use glosures instead of lambdas, so 5hell doesn't even need to support lambdas anymore! Because all commands we define with glosures are in fact just ordinary miniscript functions 👀

The reason I didn't this from the start is because glosures in Glosure were bugged and didn't evaluate correctly, so I sticked with lambdas and added 5hell support for them

But now Glosure interpreter is fixed and evaluates glosures correctly! 🌺

Sorry for this little accident!!!