### PR TITLE
Update net.5pk.src

### DIFF
--- a/5hell.5pk.src
+++ b/5hell.5pk.src
@@ -2,14 +2,14 @@
 // released v 4.3.1
 // imports .5pk files from /root/src
 // globals
-ver = "4.3.4.2_falling_skies"
+ver = "4.3.5_falling_skies"
 //print ver
 if not globals.hasIndex("DEBUG") then globals.DEBUG = false // set to true by launching 5hell with --debug as any parameter
 if globals.hasIndex("params") and globals.params.indexOf("--debug") >= 0 then 
 	globals.DEBUG = true
 	globals.params.remove(globals.params.indexOf("--debug"))
 end if
-size_of_5hell = "142.519"
+size_of_5hell = "142.532"
 globals.SILENT = 0 // 0 == normal, 2 == silent, 1 == clear_screen
 if DEBUG then print("<size=75%>loading globals...</size>") else print("<align=center><mark=red><color=black>#</color></mark></align>")
 //
@@ -26,7 +26,7 @@ globals.apt_get = null
 //
 //
 // register macros
-if DEBUG then print("<size=75%>registering macros...")
+if DEBUG then print("<size=75%>confirming macros...")
 if not get_custom_object.hasIndex("macros") then get_custom_object.macros = {}
 //
 //
@@ -1185,8 +1185,9 @@ command.run = function(arg1, arg2, arg3=0, arg4=0)
 	colorOlive+"---- eg: </b>ssh notroot@boot 192.168.0.2 | "+colorMagenta+"run /root/rkit/5hell "" brutus | rclean "" "+char(10)+char(10)+
 	colorWhite+"</b>New: you may now launch binaries by path, without prepending the path with 'run'"+char(10)+
 	"-- this is to give it more bash-like functionality"+char(10)+
-	colorMagenta+"-- eg: </b>/bin/echo "" this is new "" @B -m"
-	"Note: run supports pshells with the launch function however p_shells are not currently in game"
+	colorMagenta+"-- eg: </b>/bin/echo "" this is new "" @B -m"+char(10)
+	
+	//"Note: run supports pshells with the launch function however p_shells are not currently in game"
 	if typeof(@arg1) != "string" and typeof(@arg1) != "file" then return "run: arg1 should be file object or path to file" 
 	parameters = ""
 	rr = colorMagenta+"</b>run:"+colorWhite+"</b> launching external program..."

--- a/5hell.src
+++ b/5hell.src
@@ -321,7 +321,7 @@ command.shell = function(input=null,mute=null)
 
       if EXPERIMENTAL then 
         if fork then
-          if DEBUG then print "debug: preparing to fork"
+          if DEBUG then print "debug: preparing to "+colorRed+"5"+colorWhite+"pork"
           // prefork sanity check 
           prompt = prompt + ([0] * (5 - prompt.len)) // check this magic out 
           prompt = prompt[:5]
@@ -418,7 +418,7 @@ command.shell = function(input=null,mute=null)
       // we need this for compatibility with improperly constructed functions
       if str(@f) == "FUNCTION()" then args = 0 else args = str(@f).split(", ").len // get the number of args required by the function
       if DEBUG then print("target function takes: "+args+" arguments.")
-      if DEBUG then print("debug: preparing to fire: "+char(10)+prompt)
+      if DEBUG then print("debug:"+colorRed+" preparing to fire: "+char(10)+prompt)
       if args == 4 then
         catch = f(@prompt[1], @prompt[2], @prompt[3], @prompt[4])
       else if args == 3 then

--- a/5phinx.5pk.src
+++ b/5phinx.5pk.src
@@ -1,9 +1,9 @@
 // Sphinx Hacking Interface v 3.2 by Plu70
 
 //Define Globals
-sphinx_version = "3.3.77"
+sphinx_version = "3.3.8"
 malp_version = "1.6.6"
-if DEBUG then print("<size=75%>loading 5phinx.5pk v "+sphinx_version+" for 5hell v 4.3.4...(158.070)")
+if DEBUG then print("<size=75%>loading 5phinx.5pk v "+sphinx_version+" for 5hell v 4.3.5...(155.107)")
 
 NUM_SPLOITS = function()
   num = globals.XPLOITS.len
@@ -2006,72 +2006,6 @@ globals.memory_alpha = function(go_to_buffer=false,go_to_selection=null)
   end while
 end function
 ///////////////////////////////////// END MEMORY ALPHA ///////////////////////////
-
-// transmit 2.0 since 5hell 3.6.9
-
-globals.transmit = function(wait_for_reply=0,password)
-  if globals.T_BUF.len <= 1 then return "transmit: tbuf empty"
-  // text to send
-  send_this = globals.T_BUF.join(char(10))
-  if send_this.len <= 1 then return "transmit: buffer empty"
-   home = get_custom_object.HOME
-  // validate settings
-  if not is_valid_ip(home.ip) then return "transmit: error: please set @home ip in 5hell.src" // ["ip",port,"user","pass","service","path_to_pass"]
-  if typeof(home.loginport) != "number" then return"transmit: error: please set @home port in 5hell.src"
-
-  // connect to server. credentials compiled into 5hell.src for security
-  print colorLightBlue+"transmit: connecting to database..."
-  print(colorWhite+"---sshfs----</b>"+home.user+" @ "+home.ip+"<b>----"+CT)
-  if DEBUG then 
-    print "debug: ip: "+home.ip
-    print "debug: port: "+home.loginport+" is a "+typeof(home.loginport)
-    print "debug: user: "+home.user
-    print "debug: pass: "+home.pass
-    print "service: "+home.loginprotocol
-    print "path: "+home.sharedfile
-  end if
-  if password isa string then home.pass = password
-  if home.pass == "password" or home.pass == "" then 
-    if arg1 then home.pass = arg1 else home.pass = user_input("transmit: please the enter root passowrd of receiving server"+char(10)+"(<<b>enter</b>>=abort):> ")
-  end if
-  if home.pass == "" then return "transmit: home.pass not set; aborting..."
-  remote = shell.connect_service(home.ip,home.loginport,home.user,home.pass,home.loginprotocol)
-  if typeof(remote) != "shell" and typeof(remote) != "ftpshell" then return "transmit: unable to connect to server"+char(10)+"-- check ip and credentials and try again"
-  //
-  // make sure we have an ouput file
-  passfile = remote.host_computer.File(home.sharedfile) 
-  if not passfile then return "transmit: error: "+home.sharedfile+" not found"
-
-  // transmit
-  print "Transmitting data..."
-  t_catch = passfile.set_content(send_this)
-  // don't purge the buffer unless write successful
-  if typeof(t_catch) == "string" then return t_catch else print "Purging buffer..." 
-  // purge and reset tbuf
-  globals.T_BUF = [(localip+"@"+pubip)] 
-  //globals.T_BUF = []
-  if wait_for_reply then 
-    print "Waiting for reply..."
-    waiting = true
-    timeout = 600
-    while waiting == true
-      if passfile.get_content != send_this then waiting = false
-      wait(.1)
-      if timeout == 300 then print "timeout in 30 seconds..."
-      if timeout == 100 then print "timeout in 10 seconds..."
-      if timeout == 1 then return "transmit: timeout: no reply"
-      timeout = timeout - 1
-    end while 
-    print "Reply received..."
-    print "Storing in <b>clipa</b>"
-    reply = passfile.get_content
-    return command.clipa(reply) // will print to screen via clipa
-  else 
-    print "Skipping reply..."
-  end if
-
-  return colorLightBlue+"transmit: task complete"
-end function
 
 globals.newtree = function(a_file,quiet=0)
   if typeof(a_file) != "file" then return "tree: invalid type"

--- a/changes
+++ b/changes
@@ -31,6 +31,49 @@
 ////
 //// To Done:
 //
+// kraken: will immediately re-encrypt Map.conf after reading it
+// kraken: will accept a map_key as a final argument for all modes
+// -- except for when opening the kraken menu
+// kraken: updated usage info for: kraken prox [-gp|glasspool]
+// kraken: changed kraken prox -g/ prox -g to:
+// -- kraken prox [-gp|glasspool] and prox [-g|glasspool]
+// -- tunnels through proxy chain and opens glasspool without taking further action
+// -- (remember Marinette has a prox -g option that works a little different and launches 5hell on connecting to the endpoint)
+// kraken: kraken buffer will now populate the enum buffer with proxy shells
+// -- this will facilitate using enum -d to batch control proxies
+// prox: updated usage info for: prox [-gp|glasspool]
+// kore: --control will automatically run hashim -d in parallel with it
+// -- if kore --control detects a change to the 'pass' file used by hashim, it will invoke it
+// --note: unlike socket_in/_out behavior, hashim calls will not be created as a job
+// -- logging integration soon(tm)
+// kore: fixed crash caused by typo: cahr
+// transmit: moved from globals space in 5phinx.5pk to command.transmit in kore.5pk
+// transmit: will now accept -w as a wait flag
+// transmit: will now accept input arguments in any order:
+// --ie: transmit -w password // transmit password -w // transmit
+// transmit: updated usage info
+// -- other 'improvements' to logic
+// 5phinx.5pk: globals.transmit moved to command.transmit
+// -- malp was already calling command.transit to router to globals.transmit anyway
+// brutus: will no longer block ssh brute when glasspool is active
+// -- ssh brute through glasspool on a burner machine is, in fact, the ideal way to do it
+// ifconfig: fixed typo preventing full usage info from printing
+// -- the missing info was a note reminding the user a shell or computer may be piped to ifconfig
+// iwlist: added -b, -e, -l
+// -- -e will return only essid's
+// -- -b will return only bssid's
+// -- -l as the second argument will return a list instead of string
+
+// infil: fixed carsh caused by type 'currenPath'
+// hashim: fixed -f getting stuck in daemon mode
+// -- also, hashes will be saved to dump.txt as: user:password:hash
+// ssh: clarified usage info
+// glosure: updated usage info to inform users that lines entered into the REPL are added to up-arrow history
+// -- i forgot to document that change made in the last update
+// aptm: will now always update the sources from sources.txt before acting when run from the command line
+// -- it already does this inside the menu
+//
+//
 // glosure: changed codeStr = user_input("</> ") to codeStr = user_input("</> ",0,0,1)
 // tree: standard tree and tree -f will now use 5hell's color palette
 // -- this means theme changes, such as Marinette's, will actually change tree's appearance

--- a/contrib.5pk.src
+++ b/contrib.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading contrib.5pk for 5hell v 4.3.4...(77.229)")
+if DEBUG then print("<size=75%>loading contrib.5pk for 5hell v 4.3.5...(77.314)")
   
  //////////////////////contrubutions start here///////////
   /// this is stuff that was not made entirely by Plu70
@@ -883,7 +883,8 @@ command.glosure = function(arg1, arg2=0, arg3=0, arg4=0)
   Use (dot object method_name argument_1 argument_2 argument_N) to access a method under a grey hack object. This is dangerous and can cause crash if used incorrectly, read Manual.exe while using it.
   (at name index) essentially works like name[index], you can use it on any container.
   (set name index value) essentially works like name[index] = value, you can use it on any container. It can also used to assign any glosure to host env with globals<b>Warning: Advanced feature are not for people who dont know what they are doing! Your error will very likely result in crash!</b>
-  "
+  
+  NOTE: lines entered into the REPL will be added to the 'up-arrow' command history"
     if arg1 == "help" or arg1 == "-h" then return helpMsg
     if arg1 == "-e" or arg1 == "exec" then return execute(arg2, glosureEnv)
     if arg1 == "-E" or arg1 == "eval" then return eval(arg2, glosureEnv)

--- a/dtools.5pk.src
+++ b/dtools.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading dtools.5pk v 4.3.4..(158.758)")
+if DEBUG then print("<size=75%>loading dtools.5pk v 4.3.5..(158.780)")
 
 command.cob = function(arg1,arg2,arg3=0,arg4=0)
 	cy = colorCyan 
@@ -373,21 +373,16 @@ command.poke = function(arg1, arg2, arg3=0, arg4=0)
 	"N.B. if file a already exists then the contents will be <b>overwritten</b> if a string supplied"+char(10)+
 	"n.b.b. if the string is more than one word use piping or floating quotes to the supply string"+char(10)
 
-	skip = false
-	if arg1 == "-f" then 
-		arg1 = arg2
-		arg2 = arg3
-		arg3 = arg4
-		skip = true
-	end if
 	if arg1 == "-n" then
 		if not arg2 then return "poke: -n option requires a valid path to a file."
 		arg1 = arg2
 		arg2 = "!!nullify!!23tqg43qg34g!!"
 	end if
+	dest = globals.get_file(arg1)
+	if typeof(arg1) == "file" then dest = arg1  // needs more implementation
 	destination = null
 	final_name = null
-	dest = globals.get_file(arg1)
+	
 	if not dest then
 		split = arg1.split("/")
 		if DEBUG then print("split: "+split)
@@ -1745,7 +1740,9 @@ command.brutus = function(arg1, arg2=0, arg3=0, arg4=0)
 		"-- this is also available when using <b>mail</b> from it's menu"+char(10)+
 		"-- this does NOT use get_shell and therefore is not limited to local use"+char(10)+char(10)+
 		colorWarning+"NOTE: db <u>does not</u> translate through"+colorLightBlue+" GLASSPOOL"
-	if globals.GLASSPOOL then return colorGold+"brutus: aborting: "+colorLightBlue+"GLASSPOOL</color> is active"+char(10)+"-- brutus does not translate through glasspool"+char(10)+"-- you would be rooting your own system"
+	if globals.GLASSPOOL and (not (arg1) == "-s" and not arg1 == "-f") then return colorGold+"brutus: aborting: "+colorLightBlue+"GLASSPOOL</color> is active"+char(10)+
+	"-- brutus does not translate through glasspool"+char(10)+
+	"-- you would be rooting your own system"
 	dic = globals.dict_a
 	if DEBUG then print "debug: dict_len: "+dic.len
 	u_name = "root"

--- a/kore.5pk.src
+++ b/kore.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading kore.5pk v 4.3.4...(67.763)")
+if DEBUG then print("<size=75%>loading kore.5pk v 4.3.5...(75.130)")
 command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
     time_s = time
     kore_usage_info = "<u>"+colorGold+"KORE 3.0 || automation || helper || Goddess of the DEAD and GRAIN || rkit || security"+char(10)+char(10)+
@@ -27,18 +27,21 @@ command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
 	"-- see 5hell.src for valid colorDefinitions"+char(10)+
 	"-- you may also hard code these overrides in 5hell.src"+char(10)+
 	"-- nb: currently only color definitions may be overridden (i'm debating others)"+char(10)+char(10)+
-	//"--nb: password is <b>not</b> required for this function"+char(10)+char(10)+
 	// "Foolish: kore [--override] [ANY_GLOBAL_VARIABLE] [YOUR_POISON]"+char(10)+
 	// "-- absolutely hose yourself or another by overwriting any global variable"+char(10)+
 	// "-- you will absolutely shoot your eye out with this"+char(10)+
 	// "---- therefore in order to use it you "+colorWarning+"must enter your password"+char(10)+
 	// "---- if you have not set at least one password or have left it as default:"+char(10)+
 	// "------ this function will fail"+char(10)+
-	// "-- seriously, what kind of madperson would even use this??"+char(10)+char(10)+
+	// "-- seriously, what kind of madperson would even use this??"+char(10)+
+	// "-- jk jk, uncomment the function if you want to use it"+char(10)+
+	// "-- or use glosures to edit globals"+char(10)+
 	"Usage: kore [--silent] -- toggle silent_print mode on and off"+char(10)+
 	"-- place at the top and bottom of your do.rc to suppress startup output"+char(10)+char(10)+
 	"Usage: kore [--control] [opt:bool:spool]-- activate kore's daemon mode"+char(10)+
-	"-- creates a daemon managed by DaemonManager; see <b>shell --daemons</b>"+char(10)+
+	"-- creates a daemon managed by DaemonManager;"+char(10)+
+	"-- see <b>shell --daemons</b>"+char(10)+
+	"-- see <b>dm -h"+char(10)+
 	"-- listens on socket_in and creates a "+colorCyan+"macro"+CT+" from the contents of the file"+char(10)+
 	"-- each macro is given a job number and executed"+char(10)+
 	"-- output is written to currentPath/socket_out"+char(10)+
@@ -50,9 +53,15 @@ command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
 	"-- allows controlling one or more 5hell sessions through a single shared file"+char(10)+
 	"-- write to socket_in like any other do script"+char(10)+
 	"-- write HALT (with no other text) to socket_in to terminate kore control"+char(10)+
-	//"-- daemon manager integration soon(tm) "+char(10)+
+	"-- you may also use the Daemon Manager to stop kore's daemon, instead"+char(10)+
+	"---- see <b>dm -h"+char(10)+
 	char(10)+
-	"--n.b: cannot spool non-returned text; aka metaxploit.overflow text"+char(10)+
+	"New: kore --control will now also run <b>hashim -d</b> in parallel"+char(10)+
+	"-- write/transmit info to the same 'pass' file used by hashim to trigger"+char(10)+
+	"-- remove the pass file if you do not want kore to run hashim in parallel"+char(10)+
+	"--note: you may add and remove the file at will whiel --control is running"+char(10)+
+	char(10)+
+	"--NB: cannot spool non-returned text; aka metaxploit.overflow text"+char(10)+
 	"---- that text goes straight to the terminal and bypasses function returns"+char(10)+
 	"NOTE: writing to socket_in too quickly can cause commands to be missed!"+char(10)+
 	"-- adjust the TICK to suite your needs"+char(10)+char(10)+
@@ -72,6 +81,7 @@ command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
 		kc.log_output = null
 		kc.verbose = outer.arg3
 		kc.spool = outer.arg2
+		kc.pass_file = globals.get_file(get_custom_object.HOME.sharedfile)
 		kc.cg = colorGold
 		kc.cw = colorWhite
 		set_sockets = function()
@@ -137,6 +147,8 @@ command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
 			end if
 			print kc.cg+"<size=75%>-- "+kc.cw+"</b>listening on socket_in: <u>"+kc.socket_in.path+char(10)+kc.cg+"<"+kc.cw+"o</color>>"
 			jb = 0 // job counter
+			last_pass = ""
+			new_pass = ""
 			while running and ((daemon and manager.Check(daemon)) or not manager.__initialized)
 				if not p_validate(kc.socket_in,"name") then return colorWarning+"kore: socket_in has been deleted or otherwise invalidated"+char(10)+colorWarning+"-- aborting..."
 				new_read = kc.socket_in.get_content
@@ -150,11 +162,25 @@ command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
 						jb = jb + 1
 						print kc.cg+"<size=75%>kore: "+kc.cw+"input received; "+char(10)+kc.cw+"-- creating "+colorMagenta+"job"+jb+CT+" @ st+:"+time
 						print(command.macro("set","job"+jb,kc.socket_in.get_content.trim.replace(char(10)," |  | ")))
-						if kc.verbose then print(command.macro("-v","job"+jb),0,0,kc.socket_out.path) else print(command.macro("job"+jb),0,0,kc.socket_out.path)
-						print kc.cg+"<size=75%><u>kore: "+kc.cw+"listening on <u>"+kc.socket_in.path+"..."
+						if kc.verbose then print(command.macro("-v","job"+jb),0,0,kc.socket_out.path) else print(command.macro("job"+jb),0,0,kc.socket_out.path)	
+						print kc.cg+"<size=75%><u>kore: "+kc.cw+"listening on "+kc.socket_in.path+"..."
+						print kc.cg+"<"+kc.cw+"o</color>>"
 					end if
-					print kc.cg+"<"+kc.cw+"o</color>>"
 				end if
+
+				// experimental hashim plugin
+				if p_validate(kc.pass_file, "name") then
+					new_pass = kc.pass_file.get_content
+					if new_pass != last_pass and new_pass != "" then
+						last_pass = new_pass
+						print command.hashim("-f",kc.pass_file.path)
+						last_pass = kc.pass_file.get_content
+						print kc.cg+"<size=75%><u>kore: "+kc.cw+"listening on "+kc.socket_in.path+"..."
+						print kc.cg+"<"+kc.cw+"o</color>>"
+					end if
+				end if
+				// end experimental hashim plugin
+
 				wait(TICK)
 			end while
 			globals.spoolpath = 0
@@ -341,9 +367,15 @@ command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
 		end if
 		return "kore: invalid input"
 	end function
-	override_global = function()
-		return "you'll shoot your eye out"
-	end function
+	// override_global = function()
+	// 	o_this = outer.arg2
+	// 	consent = [ ( (globals.hasIndex(access_codes)) and globals.access_codes.indexOf(user_input("Please enter one of your 5hell access codes:"+char(10)+":> ",1)) != null ) ]
+	// 	if globals.hasIndex(o_this) and outer.arg3 and consent then
+	// 		globals.o_this = arg3
+	// 		return "kore: overriding globals.<b>"+o_this+"</b> to <b>"+arg3
+	// 	end if
+	// 	return "kore: --override requires an access_code"
+	// end function
 
 	silent_print = function()
 		if globals.SILENT == 0 then globals.SILENT = 2 else globals.SILENT = 0
@@ -351,8 +383,7 @@ command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
 	end function
      
     error = function()
-        print "kore: invalid input"
-        return 0
+        return "kore: invalid input"
     end function
     switch(str(arg1).lower)
         case("-r",@make_rkit)
@@ -364,6 +395,7 @@ command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
 		case("--override",@override_color)
 		case("--silent",@silent_print)
 		case("--control",@kore_control)
+		//case("--override-global",@override_global)
 		//case("--command",@kore_command)
     print default(@error)
     time_f = time - time_s
@@ -555,7 +587,6 @@ command.hashim = function(arg1, arg2, arg3=0, arg4=0)
 	end if
 	if arg1 != "-d" and arg1 != "-f" then return "Usage: hashim [-f|-d] [opt:path]"
 	if not crypto then print(colorOrange+"WARNING: crypto.so not found"+CT)
-	//dump = globals.get_file("dump.txt")
 	dump = command.tree("/","dump.txt",1,"N")
 	slash = "/"
 	if currentPath == "/" then slash = ""
@@ -675,8 +706,8 @@ command.hashim = function(arg1, arg2, arg3=0, arg4=0)
 				end for
 				write_this = cache.join(char(10))
 				if DEBUG then print "hashim: debug: "+char(10)+"---daeamon: "+daemon+char(10)+"---run_once: "+run_once+char(10)+"---saving: "+write_this+"---last_read: "+last_read
-				if daemon and write_this and not run_once then
-					print("Sending to swap file: "+char(10)+write_this)
+				if write_this then //and not run_once then
+					print("Sending to swap file: "+swap_file.path+char(10)+write_this)
 					swap_file.set_content(write_this)
 				end if
 				if write_this then 
@@ -1265,4 +1296,138 @@ command.outmon = function(arg1,interval=2, act=0, react=0)
 	  wait(interval)
 	end while
 	return 0
+end function
+command.transmit = function(arg1, arg2, arg3=0, arg4=0)
+	if arg1 == "-h" or arg1 == "help" then return "<b><size=75%>Transmit</b> || t_buf transmission buffer transmission protocol || @tbuf || TBUF"+char(10)+
+colorWhite+"Usage: transmit [opt: {1|0|-w}|password] [opt:password|1|-w]"+char(10)+
+"-- transmit @tbuf to your @home server
+-- set @home credentials in 5hell.src before building 5hell
+-- the HOME map is located near the top of 5hell.src
+---- set ip, port, user, and optionally a password
+-- prompts for password if not supplied or hard coded
+--note:<b> transmit will use default settings if no options supplied
+---- default is:<b> transmit 0 {HOME.pass}
+
+Options:"+char(10)+colorWhite+">> </b>arg1<b>: 1 | 0 | -w || password:
+-- [<b>1|-w</b>] == wait for reply
+---- if your password is 1 please us [-w]
+---- if your password is 0 please use the second usage
+------ eg: <b>transmit -w 0</b> will pass 0 as the password
+---- [0] (or blank) == don't wait for reply
+---- eg:<b> transmit -w
+------ uses @home password
+---- eg:<b> transmit 0 password
+-- [<b>password</b>] == use this password to transmit
+---- bypasses prompt; overrides @home setting
+---- prompts if not supplied by arg1 or arg2 or @home"+char(10)+
+char(10)+colorWhite+">> </b>arg2<b>: password || 1 | -w
+-- [<b>1|-w</b>] == wait for reply
+---- if your password is 1 please use -w
+---- if your password is 0 you may pass 0
+---- eg: transmit -w 0
+---- eg: transmit 1
+-- [<b>password</b>] == use this password to transmit
+---- bypasses prompt; overrides @home setting
+---- prompts if not supplied by arg1 or arg2 or @home
+
+<b>N.B.: transmit uses <u>globals.shell.connect_service</u> aka ssh
+<b>-- this leaves it vulnerable to metaxploit.sniffer!
+-- take appropriate precautions
+
+NOTE: use transmit with hashim running on the @home server
+---- ensure @home server has the <b>"+get_custom_object.HOME.sharedfile+"</b> file
+
+NOTE: if the default password is <b>password:
+-- transmit will <b>ignore</b> this password and prompt you for a password
+-- supply the word <b>password</b> again to confirm your password is password
+-- alternatively call the command with <b>password</b> as a second argument
+--eg: <b>transmit 1 password
+
+Current Default Password: "+colorGold+get_custom_object.HOME.pass
+
+	//return globals.transmit(arg1,arg2)
+	// transmit 2.0 since 5hell 3.6.9
+	// parse arguments
+	wait_for_reply = 0
+	password = 0 // get_custom_object.HOME.pass
+	if arg1 == "1" or arg1 == "-w" then 
+		wait_for_reply = 1
+	else
+		if arg1 isa string and arg1 != "0" then password = arg1
+	end if
+	if arg2 == "1" or arg2 == "-w" then
+		wait_for_reply = 1
+	else 
+		if arg2 isa string then password = arg2
+	end if
+
+	if globals.T_BUF.len <= 1 then return "transmit: tbuf empty"
+	// text to send
+	send_this = globals.T_BUF.join(char(10))
+	if send_this.len <= 1 then return "transmit: buffer empty"
+	home = get_custom_object.HOME
+	// validate settings
+	if not is_valid_ip(home.ip) then return "transmit: error: please set @home ip in 5hell.src" // ["ip",port,"user","pass","service","path_to_pass"]
+	if typeof(home.loginport) != "number" then return "transmit: error: please set @home port in 5hell.src"
+
+	// connect to server. credentials compiled into 5hell.src for security
+	print colorLightBlue+"transmit: connecting to database..."
+	print colorWhite+"---sshfs----</b>"+home.user+" @ "+home.ip+"<b>----"
+	if DEBUG then 
+		print "debug: ip: "+home.ip
+		print "debug: port: "+home.loginport+" is a "+typeof(home.loginport)
+		print "debug: user: "+home.user
+		print "debug: pass: "+home.pass
+		print "service: "+home.loginprotocol
+		print "path: "+home.sharedfile
+	end if
+	if not password then
+		if not home.pass or home.pass == "password" or home.pass == "" then 
+			password = user_input("transmit: please the enter @home server's "+home.user+" password"+char(10)+"(<<b>enter</b>>=abort):> ")
+			if password == "" then return "transmit: aborting..."
+		else
+			password = home.pass
+		end if
+	else
+		if password isa string then home.pass = password else return "transmit: invalid password; aborting..."
+	end if
+
+	remote = shell.connect_service(home.ip,home.loginport,home.user,home.pass,home.loginprotocol)
+	if typeof(remote) != "shell" and typeof(remote) != "ftpshell" then return "transmit: unable to connect to server"+char(10)+"-- check ip and credentials and try again"
+	//
+	// make sure we have an ouput file
+	passfile = remote.host_computer.File(home.sharedfile) 
+	if not passfile then return "transmit: error: "+home.sharedfile+" not found"
+
+	// transmit
+	print "Transmitting data..."
+	t_start = time
+	t_catch = passfile.set_content(send_this)
+	// don't purge the buffer unless write successful
+	if typeof(t_catch) == "string" then return t_catch else print "Purging buffer..." 
+	// purge and reset tbuf
+	globals.T_BUF = [(localip+"@"+pubip)] 
+	//globals.T_BUF = []
+	if wait_for_reply and wait_for_reply != "0" then 
+		print "Waiting for reply..."
+		waiting = true
+		timeout = 600
+		while waiting == true
+		if passfile.get_content != send_this then waiting = false
+		wait(.1)
+		if timeout == 300 then print "timeout in 30 seconds..."
+		if timeout == 100 then print "timeout in 10 seconds..."
+		if timeout == 1 then return "transmit: timeout: no reply"
+		timeout = timeout - 1
+		end while 
+		print "Reply received..."
+		print "Storing in <b>clipa</b>"
+		reply = passfile.get_content
+		print colorLightBlue+"transmit: task complete in ["+colorWhite+(time-t_start)+CT+"] seconds..."
+		print "-- returning reply:"
+		return command.clipa(reply) // will print to screen via clipa
+	else 
+		print "Skipping reply..."
+	end if
+	return colorLightBlue+"transmit: task complete in ["+colorWhite+(time-t_start)+CT+"] seconds..."
 end function

--- a/net.5pk.src
+++ b/net.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading net.5pk v 4.3.4...(151.342)")
+if DEBUG then print("<size=75%>loading net.5pk v 4.3.5...(152.933)")
 
 command.target = function(arg1, arg2, arg3=0, arg4=0)
 	if arg1 == "-h" or arg1 == "help" then return "Target || Target IP || Target Port"+char(10)+"Usage: target -- return current target ip and port"+char(10)+"Usage: target ip -- returns current target ip"+char(10)+"Usage: target pt -- return current target port"+char(10)+"Usage: target [ip] -- set target ip address (ip must be a valid ip)"+char(10)+"Usage: target -p [port] -- set target port (returns target port if not supplied)"+char(10)+"Usage: target [ip] [port] -- set targt ip and port in a single command"+char(10)+char(10)+"Note: target ip and port are used by 5phinx, transmit, meta, db, probe, and others."
@@ -46,28 +46,6 @@ command.target = function(arg1, arg2, arg3=0, arg4=0)
 	end if
 	print "<size=75%>target: returning targetIP and targetPort:"
 	return globals.targetIP+" "+globals.targetPort
-end function
-command.transmit = function(arg1, arg2, arg3=0, arg4=0)
-	if arg1 == "-h" or arg1 == "help" then return "<b><size=75%>Transmit</b> || t_buf transmission buffer transmission protocol || @tbuf || TBUF"+char(10)+
-	"Usage: transmit [opt: 1|0] [opt:password] "+char(10)+
-	"-- transmit @t_buf to your @home server. "+char(10)+
-	"-- set @home credentials in 5hell.src before building 5hell"+char(10)+
-	"-- options: 1 == wait for reply, 0 (or blank) == don't wait for reply"+char(10)+
-	"--eg:</b> transmit 1"+char(10)+"--eg:<b> transmit 0"+char(10)+
-	"-- use with hashim running on the @home server"+char(10)+
-	"---- ensure @home server has the <b>"+get_custom_object.HOME.sharedfile+"</b> file"+char(10)+
-	"-- if <b>HOME.pass is not set or left at default:"+char(10)+
-	"---- you will be prompted for the password when running the command"+char(10)+
-	"-- pass a second argument to bypass the prompt"+char(10)+
-	"--eg: transmit 0 securePassword"+char(10)+char(10)+
-	"NOTE: the default password is <b>password"+char(10)+
-	"-- transmit will ignore this and prompt you for a password"+char(10)+
-	"-- supply the word <b>password</b> again to confirm your password is password"+char(10)+
-	"-- alternatively call the command with <b>password</b> as a second argument"+char(10)+
-	"--eg: <b>transmit 1 password"+char(10)+
-	char(10)+
-	"Current Default Password: "+colorGold+get_custom_object.HOME.pass
-	return globals.transmit(arg1,arg2)
 end function
 command.rsi = function(arg1, arg2, arg3=0, arg4=0)
 	if arg1 == "help" or arg1 == "-h" then return "<b><u>Reverse Shell Interface || RSI Daemon || Install rshell server"+char(10)+
@@ -414,29 +392,44 @@ command.scpm = function(arg1, arg2, arg3=0, arg4=0)
 	return globals.secure_copy(target_shell, target_path, direction, skip)
 end function
 command.iwlist = function(arg1, arg2=0, arg3=0, arg4=0)
-	if arg1 == "help" or arg1 == "-h" then return "<u>iwlist || wifi networks "+char(10)+
-	colorGreen+"Usage: iwlist -- returns a string containing all wifi networks in range"+char(10)+
-	"-- displays bssid, essid, and signal strenghth (power)"+char(10)+
-	"-- note: use <b>ifconfig -w</b> or <b>air</b> to connect wifi"+char(10)+
-	"Usage: iwlist [-a|air] -- uses the command:<b> air false</b> to display network info "
-	nets = localmachine.wifi_networks("wlan0")
-	print colorGreen+"<u><size=75%>"+colorWhite+"- - - - - - wifi networks - - - - - -"
-	if arg1 == "-a" or arg1 == "air" then
-		return command.air("false")
-	else 
-		if typeof(nets) == "list" then return nets.join(char(10))
+	if arg1 == "help" or arg1 == "-h" then return "<u>iwlist || wifi networks || essid || bssid"+char(10)+char(10)+
+	colorGreen+"Usage: iwlist [opt:-l] -- returns all wifi networks in range"+char(10)+
+	"-- displays bssid, essid, and signal strenghth (power/pwr)"+char(10)+
+	"-- note: use <b>ifconfig -w</b> or <b>air</b> to connect to wifi"+char(10)+
+	colorGreen+"Usage: iwlist [-a|air] -- uses the command:<b> air false</b> to display network info "+char(10)+
+	"-- does not accept the -l argument"+char(10)+
+	colorGreen+"Usage: iwlist [-b] [opt:-l] -- return BSSID's of all wifi signals in range"+char(10)+
+	colorGreen+"Usage: iwlist [-e] [opt:-l] -- return ESSID's of all wifi signals in range"+char(10)+
+	colorGreen+"Usage: iwlist [-p] [opt:-l] -- return power % of all wifi signals in range"+char(10)+char(10)+
+	"NOTE: by default iwlist returns a string"+char(10)+
+	"-- passing <b>-l</b> as second argument returns a <b>list</b>"+char(10)
+	return_list = false
+	if arg1 == "-a" or arg1 == "air" then return command.air("false")
+	if agr2 == "-l" then return_list = true
+	nets = localmachine.wifi_networks("wlan0").split(char(10))
+	c = 0
+	if arg1 == "-b" or arg1 == "-e" then 
+		if arg1 == "-e" then c = 2
+		colm = []
+		for line in nets
+			line = line.trim
+			colm.push(line.split(" ")[c])
+		end for
+		nets = colm
 	end if
+	if not return_list then nets = nets.join(char(10))
+	print colorGreen+"<u><size=75%>"+colorWhite+"- - - - - - wifi networks - - - - - -"
 	return nets	
 end function
 command.ifconfig = function(arg1=0, arg2=0, arg3=0, arg4=0)
 	if arg1 == "help" or arg1 == "-h" then 
 		clb = colorLightBlue
 		return "ifconfig || iwconfig || wifi || ethernet || internet || gateway || router"+char(10)+
-			"Usage: ifconfig [opt:"+clb+"-l|-p|-c|-w|-g|-d"+CT+"] --  returns network interface information"+char(10)+char(10)+
-			"Usage: <b>ifconfig</b> -- returns connection status and ip information of active computer object"+char(10)+char(10)+
-			"Usage: ifconfig ["+clb+"-l"+CT+"|local] -- returns the lan ip of the active computer object"+char(10)+
+			"Usage: ifconfig [opt:"+clb+"-l|-p|-c|-w|-g|-d"+CT+"] [opt:shell|computer] --  returns network interface information"+char(10)+char(10)+
+			"Usage: <b>ifconfig</b> [opt:shell|computer] -- returns connection status and ip information"+char(10)+char(10)+
+			"Usage: ifconfig ["+clb+"-l"+CT+"|local] [opt:shell|computer] -- returns the lan ip of the active computer object"+char(10)+
 			"-- respects glasspool"+char(10)+char(10)+
-			"Usage: ifconfig ["+clb+"-p"+CT+"|public] -- returns the public ip of the active object computer object"+char(10)+
+			"Usage: ifconfig ["+clb+"-p"+CT+"|public] [opt:shell|computer] -- returns the public ip of the active object computer object"+char(10)+
 			"-- respects glasspool"+char(10)+char(10)+
 			"Usage: ifconfig ["+clb+"-c"+CT+"|connect] [desired_lan_ip] [desired_gateway] "+char(10)+
 			"-- connect via ethernet to gateway and request lan_ip."+char(10)+
@@ -446,28 +439,38 @@ command.ifconfig = function(arg1=0, arg2=0, arg3=0, arg4=0)
 			"-- this a slightly simpler iwconfig:"+char(10)+
 			"---- you pass an essid OR a bssid, not both"+char(10)+
 			"-- note: use <b>air</b> for cracking wifi networks or accessing wifi via a menu"+char(10)+char(10)+
-			"Usage: ifconfig ["+clb+"-g"+CT+"|gateway] -- returns the lan ip of the active object's gateway (router)"+char(10)+char(10)+
-			"Usage: ifconfig ["+clb+"-d"+CT+"|devices] -- list network devices on active computer object"+char(10)
+			"Usage: ifconfig ["+clb+"-g"+CT+"|gateway] [opt:shell|computer] -- returns the lan ip of the active object's gateway (router)"+char(10)+char(10)+
+			"Usage: ifconfig ["+clb+"-d"+CT+"|devices] [opt:shell|computer] -- list network devices on active computer object"+char(10)+char(10)+
+			colorGreen+"Note: ifconfig> shows localmachine by default"+char(10)+
+			"-- pipe an object to configure a remote machine instead"+char(10)
 		end if
 	print colorGreen+"- - - - - - - - - - - - - - - - - - - - - - -"
 	dat = []
 	globals.localip = globals.localmachine.local_ip
 	globals.pubip = globals.localmachine.public_ip
+	use_comp = globals.localmachine
+
+	if typeof(arg1) == "shell" or typeof(arg1) == "computer" or typeof(arg2) == "shell" or typeof(arg2) == "computer" then
+		use_comp = arg2
+		if typeof(arg2) == "shell" then use_comp == arg2.host_computer
+	end if
 	if arg1 == "-l" or arg1 == "local" or arg2 == "-l" or arg2 == "local" then dat.push(localip)// ?? #whyemoji.gif
 	if arg1 == "-p" or arg1 == "public" or arg2 == "-p" or arg2 == "public" then dat.push(pubip)// ??
 	if arg1 == "-d" or arg2 == "-d" or arg1 == "devices" or arg2 == "devices" then// ??
 		dat.push("___")
-		dat.push(localmachine.network_devices)
+		dat.push(use_comp.network_devices)
 	end if
+
+	if typeof(arg1) == "shell" or typeof(arg1) == "computer" then 
 	if arg1 == "-w" or arg1 == "wifi" then 
 		if not arg3 then return "ifconfig: -w expects [essid|bssid] [passykey]"
-		if not localmachine.active_net_card == "WIFI" then return "iwconfig: no active WIFI card"
-		dev = localmachine.network_devices
+		if not use_comp.active_net_card == "WIFI" then return "iwconfig: no active WIFI card"
+		dev = use_comp.network_devices
 		if dev.indexOf("wlan0") != null then dev = "wlan0"
 		if dev.indexOf("wlan1") != null then dev = "wlan1"
 		essid = 0
 		bssid = 0
-		networks = localmachine.wifi_networks(dev)
+		networks = use_comp.wifi_networks(dev)
 		if DEBUG then print "debug: networks: "+networks.join(char(10))
 		for net in networks 
 			net = net.split(" ")
@@ -478,7 +481,7 @@ command.ifconfig = function(arg1=0, arg2=0, arg3=0, arg4=0)
 		end for
 		if DEBUG then print "debug: essid: "+essid+" bssid: "+bssid
 		if not essid or not bssid then return "ifconfig: error; no such wifi network"
-		return localmachine.connect_wifi(dev,bssid,essid,arg3)
+		return use_comp.connect_wifi(dev,bssid,essid,arg3)
 	end if
 	if arg1 == "-c" or arg1 == "connect" then
 		device = "eth0"
@@ -486,22 +489,22 @@ command.ifconfig = function(arg1=0, arg2=0, arg3=0, arg4=0)
 		gateway = arg3
 		if not is_valid_ip(address) then return("ifconfig: invalid ip address")
 		if not is_valid_ip(gateway) then return("ifconfig: invalid gateway")
-		output = localmachine.connect_ethernet(device, address, gateway)
+		output = use_comp.connect_ethernet(device, address, gateway)
 		return output
 	end if
-	if arg1 == "-g" or arg1 == "gateway" then return localmachine.network_gateway
+	if arg1 == "-g" or arg1 == "gateway" then return use_comp.network_gateway
 	if arg1 == 0 and arg2 == 0 then //dat.push(pubip)
-		if localmachine.is_network_active then
-			router = get_router(localmachine.network_gateway)
+		if use_comp.is_network_active then
+			router = get_router(use_comp.network_gateway)
 			if not router then 
-				dat.push("ifconfig: error: gateway: "+localmachine.network_gateway)
+				dat.push("ifconfig: error: gateway: "+use_comp.network_gateway)
 			end if
-			dat.push("Connected to: "+localmachine.active_net_card)
-			if localmachine.active_net_card == "WIFI" then
+			dat.push("Connected to: "+use_comp.active_net_card)
+			if use_comp.active_net_card == "WIFI" then
 				if router then dat.push("<b>"+router.essid_name+"</b>")
 				if router then dat.push(router.bssid_name)
 			end if
-			dat.push(localmachine.network_gateway+char(10)+"<b>"+localmachine.public_ip+char(10)+"<b>"+localmachine.local_ip)
+			dat.push(use_comp.network_gateway+char(10)+"<b>"+use_comp.public_ip+char(10)+"<b>"+use_comp.local_ip)
 		else
 			dat.push(char(10)+"No active network connection."+char(10))
 		end if
@@ -997,7 +1000,14 @@ command.whois = function(arg1, arg2, arg3=0, arg4=0)
 end function
 command.ssh = function(arg1, arg2, arg3=0, arg4="ssh")
 	ssh_help = function()
-		return "Secure Shell Protocol"+char(10)+"Usage: ssh [user@pass] [ip] [optional:pt (default 22)]"+char(10)+"ssh_usage: ssh [user@-brutus] [ip] [opt:pt] --  remote brute force attack"+char(10)+"e.g. ssh root@1234 1.1.1.1 "+char(10)+"e.g. ssh root@-brutus 1.2.3.4 21 ftp"+char(10)+"Sends shells to BUFFER or you may open immediately."
+		return "secure shell protocol || connect_service"+char(10)+
+		"Usage: ssh [user@pass] [ip] [optional:port (default 22)] [opt:ftp]"+char(10)+
+		"--eg: <b>ssh root@1234 1.1.1.1 "+char(10)+
+		"Usage: ssh [user@-brutus] [ip] [opt:pt] --  remote brute force attack"+char(10)+
+		"--eg: <b>ssh root@-brutus 1.2.3.4 21 ftp"+char(10)+
+		"NOTE: passing ftp is required when connect to an ftp server"+char(10)+
+		"Note: sends shells to BUFFER"+char(10)+
+		"NOTE: returns the shell object"+char(10)
 	end function
 	if arg1 == 0 or arg2 == 0 or arg1 == "-h" or arg1 == "help" then return ssh_help
 	if not localmachine.is_network_active then return "nsl: no network connection."
@@ -1092,12 +1102,16 @@ command.scrub = function(arg1, arg2=0, arg3=0, arg4=0)
 	return command.kraken("scrub", arg1, arg2)
 end function
 command.prox = function(arg1, arg2=0, arg3=0, arg4=0)
-	if arg1 == "-h" or arg1 == "help" then return "KRAKEN shortcut || proxy tunneling"+char(10)+"
-	Usage: prox -- use kraken to route through proxy net and open terminal at end"+char(10)+
-	"-- equivalent to<b> kraken connect"+char(10)+
-	"-- if Map.conf is encrypted you may pass a decryption key as an argument"+char(10)+
-	"---- otherwise you will be prompted for the key"
-	return command.kraken("connect", arg1, arg2)
+	if arg1 == "-h" or arg1 == "help" then return "KRAKEN shortcut || proxy tunneling"+char(10)+
+	"<b>Usage: prox [opt:map_key] -- use kraken to route through proxy net and open terminal at end"+char(10)+
+	"-- equivalent to<b> kraken prox"+char(10)+
+	"-- if Map.conf is encrypted:"+char(10)+
+	"-- the HOME.map_key, if set, will be used to decrypt"+char(10)+
+	"-- or you may pass a decryption key as an rgument"+char(10)+
+	"<b>Usage: prox [opt:-gp|glasspool] [opt:map_key] --"+char(10)+
+	"-- use kraken to route through proxy net and start "+colorLightBlue+"GLASSPOOL"+char(10)+
+	"-- does not start_terminal on endpoint proxy"
+	return command.kraken("prox", arg1, arg2)
 	return 0
 end function
 if DEBUG then print("<size=75%>loading ...kraken.5pk...(10.875b)</size>")
@@ -1105,48 +1119,56 @@ if DEBUG then print("<size=75%>loading ...kraken.5pk...(10.875b)</size>")
 command.kraken = function(arg1, arg2=0, arg3=0, arg4=0) // release the kraken!
 	kraken_help = function()
 		return "proxy management || release the kraken || upload || download || rental server"+char(10)+
-		"Usage: kraken [opt: upload_path] -- propagate file or folder to all proxies"+char(10)+
+		colorGold+"Usage: kraken [opt: upload_path] [opt:map_key] -- propagate file or folder to all proxies"+char(10)+
 		"-- uses ~/Config/Map.conf"+char(10)+
 		"-- does <b>not</b> scrub the log after uploading"+char(10)+char(10)+
-		"Usage: kraken prox -- tunnel through each proxy and start_terminal on the last"+char(10)+
+		colorGold+"Usage: kraken prox [opt:map_key] --"+char(10)+
+		"-- tunnel through each proxy and start_terminal on the last"+char(10)+
 		"-- each proxy uses ssh to connect to the next, in order"+char(10)+
 		"-- start_terminal will be used on the endpoint proxy"+char(10)+
 		"-- scrubs the logs before starting the terminal"+char(10)+
-		"--note: this mode has been aliased to the "+colorCyan+"prox"+CT+" command (<b>prox -h</b>)"+char(10)+
-		"Usage: kraken prox [opt:"+colorLightBlue+"-g"+CT+"] -- tunnel through each proxy <b>w/o</b> starting the terminal"+char(10)+
-		"-- opens the final shell in the chain in "+colorLightBlue+"glasspool"+CT+" instead"+char(10)+
+		"--note: this mode has been aliased to the "+colorCyan+"prox"+CT+" command (<b>prox -h</b>)"+char(10)+char(10)+
+		colorGold+"Usage: kraken prox [opt:"+colorLightBlue+"-gp|glasspool"+CT+"] [opt:map_key] --"+char(10)+
+		"-- tunnel through each proxy and open "+colorLightBlue+"GLASSPOOL"+char(10)+
+		"-- does <b>not</b> run <b>start_termianl</b> on the final 5hell"+char(10)+
+		"-- opens glasspool on final terminal instead"+char(10)+
 		"-- all shells in the chain remain in the "+colorOrange+"BUFFER"+char(10)+char(10)+
-		"Usage: kraken scrub -- tunnel through proxy chain and corrupt the log on each"+char(10)+
+		colorGold+"Usage: kraken scrub [opt:map_key] --"+char(10)+
+		"-- tunnel through proxy chain and corrupt the log on each"+char(10)+
 		"--note: this mode has been aliased to the "+colorCyan+"scrub"+CT+" command (<b>scrub -h</b>)"+char(10)+
 		"-- <b>kraken scrub / scrub</b> will:"+char(10)+
 		"---- corrupt the log on each proxy in the chain"+char(10)+
 		"---- remove /etc/passwd from each proxy in the chain"+char(10)+
 		"---- lock file permissions on each proxy in the chain"+char(10)+char(10)+
-		"Usage: kraken [buffer] -- shells will be sent to BUFFER with no further action"+char(10)+char(10)+
-		//"New: kraken [command] [-s] -- run silentclean each proxy after the command"+char(10)+
-		//"--eg: kraken /root/rkit -s"+char(10)+char(10)+
-		"Usage: kraken add [opt:ip] [opt:pass] -- add items to Map.conf"+char(10)+char(10)+
-		"Usage: kraken del [index] -- remove the entry at index"+char(10)+
-		"Usage: kraken show [opt:-p] -- display proxy list"+char(10)+
+		colorGold+"Usage: kraken [buffer] [opt:map_key] -- "+char(10)+
+		"-- send all proxy shells to BUFFER and enum"+char(10)+char(10)+
+		colorGold+"Usage: kraken add [opt:ip] [opt:pass] [opt:map_key] -- add items to Map.conf"+char(10)+
+		colorGold+"Usage: kraken del [index] [opt:map_key] -- remove the entry at index"+char(10)+char(10)+
+		colorGold+"Usage: kraken show [opt:-p] [opt:map_key] -- display proxy list"+char(10)+
 		"-- passing<b> -p</b> will display the list with passwords"+char(10)+char(10)+
-		"Usage: kraken [-l|logs]  -- download system.log from proxies and then scrub"+char(10)+
+		colorGold+"Usage: kraken [-l|logs] [opt:map_key] -- download system.log from proxies and then scrub"+char(10)+
 		"-- system.logs are saved as: <b>system-#.log"+char(10)+
 		"-- # is in the reverse order of the proxy chain"+char(10)+
 		"---- the <b>endpoint</b> log will have the lowerst number"+char(10)+
 		"-- logs are<b> not</b> overwritten on each run; mind your drive space"+char(10)+char(10)+
-		colorGold+"Usage: kraken -- launch the kraken proxy management menu"+char(10)+
+		colorGold+"Usage: "+colorOrange+"kraken</color> -- launch the kraken proxy management menu"+char(10)+
+		"-- note: this mode does not take a map_key as input"+char(10)+
+		"---- set HOME.map_key or enter map_key at prompt"+char(10)+
 		char(10)+
 		"NOTE: kraken will only scrub logs when using:"+char(10)+
 		"-- scrub, prox, [-l|logs]"+char(10)+char(10)+
 		colorGold+"Encryption"+CT+colorWhite+" and "+CT+colorGold+"Kraken"+char(10)+
-		"-- kraken will [offer to] decrypt Map.conf if it is encrypted"+char(10)+
-		"---- files decrypted this way will be re-encrypted"
+		"-- kraken will attempt to decrypt Map.conf if it is encrypted"+char(10)+
+		"---- files decrypted this way will be re-encrypted"+char(10)+
+		"-- you may set a decryption key in HOME.map_key"+char(10)+
+		"-- or pass it as a final argument"
+		
 	end function
 	if arg1 == "-h" or arg1 == "help" then return kraken_help
 	map_path = home_dir + "/Config/Map.conf"
 	map_file = globals.get_file(map_path)
 	kraken_done = function(msg="kraken: task complete")
-		if outer.isenc then print command.file("-e",outer.map_file.path,outer.enckey)
+		//if outer.isenc then print command.file("-e",outer.map_file.path,outer.enckey)
 		return msg
 	end function
 	if not map_file then
@@ -1167,6 +1189,9 @@ command.kraken = function(arg1, arg2=0, arg3=0, arg4=0) // release the kraken!
 			enckey = arg2
 			if arg2 == "-p" or arg1 == "del" then enckey = arg3 
 			if arg1 == "add" then enckey = arg4
+			if arg1 == "prox" then
+				if arg2 == "-gp" or arg2 == "glasspool" then enckey = arg3 else enckey = arg2
+			end if
 			if not enckey then enckey = command.cob("get","HOME.map_key") 
 			if globals.DEBUG then print "debug: map path: "+map_file.path+char(10)+"-- arg1: "+arg1+", enckey: "+enckey
 			print command.file("-d",map_file.path,enckey)
@@ -1175,7 +1200,9 @@ command.kraken = function(arg1, arg2=0, arg3=0, arg4=0) // release the kraken!
 		end if
 		if map_file.is_binary then return "kraken: "+colorWarning+"decryption failed; aborting..."
 	end if
+	print "kraken: reading Map.conf"
 	map_contents = map_file.get_content
+	if isenc then print command.file("-e",map_file.path,enckey)
 	//map read
 	print(colorCyan+"Initializing Kraken v 0.9.5 by Plu70..."+CT)
 	time_s = time
@@ -1309,9 +1336,22 @@ command.kraken = function(arg1, arg2=0, arg3=0, arg4=0) // release the kraken!
 	print("Proxy net consists of "+proxy["accounts"].len + " nodes: ")
 	print(colorOrange+"</b>!Kraken will no longer scrub your proxy logs by default!<b>"+CT)
 	print(colorOrange+"</b>Run:<b> scrub</b> or<b> kraken scrub </b>manually to corrupt logs."+CT)
-	print(colorOrange+"</b>Logs <u>will</u> be scrubbed for: <b>kraken connect</b> and the <b>prox</b> command.")
+	print(colorOrange+"</b>Logs <u>will</u> be scrubbed for: <b>kraken prox</b> and the <b>prox</b> command.")
 	last_shell = shell
-	if not waitFor then waitFor = user_input("["+colorCyan+"/path/to_file_or_folder"+CT+"] = upload to all proxies and BUFFER shells"+char(10)+"["+colorWhite+"prox"+CT+"] route through proxies and open shell at last proxy "+char(10)+"["+colorWhite+"-l"+CT+"] download (then scrub) proxy logs and BUFFER shells"+char(10)+"["+colorWhite+"scrub"+CT+"] scrub logs on all proxies and BUFFER shells"+char(10)+"["+colorWhite+"show"+CT+"] show ips of proxies in map"+char(10)+"["+colorWhite+"add"+CT+"] add proxy to map "+char(10)+"["+colorWhite+"del"+CT+"] remove proxy from map "+char(10)+"["+colorWhite+"buffer"+CT+"] = add all proxies to BUFFER without scrubbing"+char(10)+"[help] show help"+" [q]=quit "+char(10)+"kraken:> ",0,0)
+	if not waitFor then waitFor = user_input("["+colorCyan+"/path/to_file_or_folder"+CT+"] = upload to all proxies and BUFFER shells"+char(10)+
+	"["+colorWhite+"prox"+CT+"] route through proxies and start_terminal at last proxy "+char(10)+
+	"["+colorWhite+"glasspool"+CT+"] as above but opens glasspool instead start_terminal"+char(10)+
+	"["+colorWhite+"-l"+CT+"] download (then scrub) proxy logs and BUFFER shells"+char(10)+
+	"["+colorWhite+"scrub"+CT+"] scrub logs on all proxies and BUFFER shells"+char(10)+
+	"["+colorWhite+"show"+CT+"] show ips of proxies in map"+char(10)+
+	"["+colorWhite+"add"+CT+"] add proxy to map "+char(10)+
+	"["+colorWhite+"del"+CT+"] remove proxy from map "+char(10)+
+	"["+colorWhite+"buffer"+CT+"] = add all proxies to BUFFER without scrubbing"+char(10)+
+	"[help] show help"+" [q]=quit "+char(10)+"kraken:> ",0,0)
+	if waitFor == "glasspool" or waitFor == "-gp" or waitFor == "-G" then 
+		glass = true
+		arg2 = "glasspool"
+	end if
 	if globals.DEBUG then "debug: user input: "+arg1+" "+arg2+" "+arg3+" "+arg4+"-- waitFor: "+waitFor
 	if waitFor == "q" or waitFor == "Q" or waitFor == "" then return kraken_done("Aborting...")
 	if waitFor == "help" or waitFor == "-h" then return kraken_help
@@ -1375,7 +1415,7 @@ command.kraken = function(arg1, arg2=0, arg3=0, arg4=0) // release the kraken!
 		if waitFor == "connect" or waitFor == "prox" then
 			connect = true
 			if not proxy["accounts"].len then return kraken_done( "kraken: no proxy found.")
-			if arg2 == "-g" then
+			if arg2 == "-gp" or arg2 == "glasspool" then
 				connect = false 
 				glass = true 
 			end if
@@ -1385,7 +1425,7 @@ command.kraken = function(arg1, arg2=0, arg3=0, arg4=0) // release the kraken!
 	end if
 	if waitFor == "secure" then secure = true
 	fileOrFolder = "scrub"
-	if not scrub and not buffer then fileOrFolder = localmachine.File(waitFor)
+	if not scrub and not buffer then fileOrFolder = globals.get_file(waitFor)
 	if not fileOrFolder then return kraken_done( "kraken: file not found.")
 	upload_path = "scrub"
 	if not scrub and not buffer then upload_path = fileOrFolder.path
@@ -1453,10 +1493,10 @@ command.kraken = function(arg1, arg2=0, arg3=0, arg4=0) // release the kraken!
 	print(colorCyan+"////////////////////////////////////////////////////////"+CT)
 	if connect or glass then 
 		if DEBUG then print "debug: connect: "+connect+char(10)+"debug: glass: "+glass
-		hold = globals.shell 
-		globals.shell = remote
+		//hold = globals.shell 
+		//globals.shell = remote
 		if connect == true then print command.psudo("-l",remote) else print command.glasspool(remote) // we want glass to mimic connect's behavior if the user uses start_terminal after using glass
-		globals.shell = hold 
+		//globals.shell = hold 
 	end if
 	return kraken_done
 end function
@@ -2426,7 +2466,7 @@ command.aptm = function(arg1, arg2, arg3=0, arg4=0) // requires aptclient.so
 	"-- when used on a remote 'silent launch' of 5hell"+char(10)+
 	"---- pipes aptclientLib to the custom object then exits back to original 5hell"+char(10)+
 	"-- cob get apt | aptm"+char(10)+
-	"---- pipes aptclientLib to aptm and changes scope of aptm to remote"+char(10)+
+	"---- pipes aptclientLib to aptm and changes scope of aptm to remote"+char(10)+char(10)+
 	"Advanced: press [7] hot_swap_libs in aptm "+char(10)+
 	"-- reloads meta/crypto/apt to use latest versions after updating"+char(10)+char(10)+
 	"APT command line options (skips the menu):"+char(10)+
@@ -2498,12 +2538,17 @@ command.aptm = function(arg1, arg2, arg3=0, arg4=0) // requires aptclient.so
 			return print(chk_upg(cup)) // when using a remote aptclientlib, a file may be on the target that is not on the attacking machine
 	end function
 	apt.add_repo = function()
-		apt.update
-	  	if typeof(arg2) == "string" and is_valid_ip(arg2)then a = arg2 else a = user_input("Add repo ip:> ")
-			if is_valid_ip(a) then return print(apt_get.add_repo(a)) else return "aptm: invalid repo ip"
+	  	if typeof(arg2) == "string" and is_valid_ip(arg2) then a = arg2 else a = user_input("Add repo ip:> ")
+		if is_valid_ip(a) then
+			print "aptm: adding repo: "+a
+			print apt_get.add_repo(a)
+			apt.update
+		else
+			return "aptm: invalid repo ip"
+		end if
 	end function
 	apt.del_repo = function()
-		apt.update
+		//apt.update // this is called by apt.list_repos
 		rl = apt.list_repos
 		if rl.len < 1 then return print("aptm: no repositories to delete")
 		i = 0
@@ -2522,7 +2567,8 @@ command.aptm = function(arg1, arg2, arg3=0, arg4=0) // requires aptclient.so
 			a = a.to_int
 			if a >= 0 and a < rl.len then a = rl[a] else return print("aptm: invalid index")
 		end if
-		return print(apt_get.del_repo(a)) 
+		print(apt_get.del_repo(a)) 
+		apt.update
 	end function
 	apt.list_repos = function()
 		apt.update
@@ -2542,6 +2588,7 @@ command.aptm = function(arg1, arg2, arg3=0, arg4=0) // requires aptclient.so
 		return reps
 	end function
 	apt.install = function()
+		apt.update
 		if typeof(arg2) == "string" and arg2 != "" then return print(apt_get.install(arg2,arg3)) else return print(apt_get.install(user_input("Install File(<<b>enter</b>>=abort):><b> "), user_input("Install Directory (<<b>enter</b>>=default)"+char(10)+":> ")))
 	end function
 	apt.search = function()
@@ -2562,9 +2609,10 @@ command.aptm = function(arg1, arg2, arg3=0, arg4=0) // requires aptclient.so
 	end function
 	apt.update = function()
 	  print "<size=75%>Updating repositories..."
-	  return print(apt_get.update)
+	  apt_get.update
+	  return 1
 	end function
-	
+	//apt_get.update // always update on launch
 	// check for cli launch args
 	apting = false 
 	if not arg2 then arg2 = ""
@@ -2599,7 +2647,7 @@ command.aptm = function(arg1, arg2, arg3=0, arg4=0) // requires aptclient.so
 		a_choice = user_input("(q=quit)||: ",0,1).to_int
 		if a_choice == 0 or a_choice == "q" then return 0
 		if typeof(a_choice) != "number" or a_choice >= i or a_choice < 0 then continue
-		print(apt.indexes[a_choice])
+		print "aptm: selected "+apt.indexes[a_choice]
 		ap = apt[apt.indexes[a_choice]]
 		ap
 		print("_____________________________________________")


### PR DESCRIPTION
// kraken: will immediately re-encrypt Map.conf after reading it
// kraken: will accept a map_key as a final argument for all modes
// -- except for when opening the kraken menu
// kraken: updated usage info for: kraken prox [-gp|glasspool]
// kraken: changed kraken prox -g/ prox -g to:
// -- kraken prox [-gp|glasspool] and prox [-g|glasspool]
// -- tunnels through proxy chain and opens glasspool without taking further action
// -- (remember Marinette has a prox -g option that works a little different and launches 5hell on connecting to the endpoint)
// kraken: kraken buffer will now populate the enum buffer with proxy shells
// -- this will facilitate using enum -d to batch control proxies
// prox: updated usage info for: prox [-gp|glasspool]
// kore: --control will automatically run hashim -d in parallel with it
// -- if kore --control detects a change to the 'pass' file used by hashim, it will invoke it
// --note: unlike socket_in/_out behavior, hashim calls will not be created as a job
// -- logging integration soon(tm)
// kore: fixed crash caused by typo: cahr
// transmit: moved from globals space in 5phinx.5pk to command.transmit in kore.5pk
// transmit: will now accept -w as a wait flag
// transmit: will now accept input arguments in any order:
// --ie: transmit -w password // transmit password -w // transmit
// transmit: updated usage info
// -- other 'improvements' to logic
// 5phinx.5pk: globals.transmit moved to command.transmit
// -- malp was already calling command.transit to router to globals.transmit anyway
// brutus: will no longer block ssh brute when glasspool is active
// -- ssh brute through glasspool on a burner machine is, in fact, the ideal way to do it
// ifconfig: fixed typo preventing full usage info from printing
// -- the missing info was a note reminding the user a shell or computer may be piped to ifconfig
// iwlist: added -b, -e, -l
// -- -e will return only essid's
// -- -b will return only bssid's
// -- -l as the second argument will return a list instead of string
// infil: fixed carsh caused by type 'currenPath'
// hashim: fixed -f getting stuck in daemon mode
// -- also, hashes will be saved to dump.txt as: user:password:hash
// ssh: clarified usage info
// glosure: updated usage info to inform users that lines entered into the REPL are added to up-arrow history
// -- i forgot to document that change made in the last update
// aptm: will now always update the sources from sources.txt before acting when run from the command line
// -- it already does this inside the menu