### PR TITLE
Update net.5pk.src

### DIFF
--- a/5hell.5pk.src
+++ b/5hell.5pk.src
@@ -2,14 +2,14 @@
 // released v 4.3.1
 // imports .5pk files from /root/src
 // globals
-ver = "4.3.6.3_falling_skies"
+ver = "4.3.7_falling_skies"
 //print ver
 if not globals.hasIndex("DEBUG") then globals.DEBUG = false // set to true by launching 5hell with --debug as any parameter
 if globals.hasIndex("params") and globals.params.indexOf("--debug") >= 0 then 
 	globals.DEBUG = true
 	globals.params.remove(globals.params.indexOf("--debug"))
 end if
-size_of_5hell = "144.577"
+size_of_5hell = "145.164"
 globals.SILENT = 0 // 0 == normal, 2 == silent, 1 == clear_screen
 if DEBUG then print("<size=75%>loading globals...</size>") else print("<align=center><mark=red><color=black>#</color></mark></align>")
 //
@@ -1917,7 +1917,7 @@ command.rclean = function(arg1, arg2=0, arg3=0, arg4=0)
 	end if
 	//if not arg1 then arg1 = globals.shell
 	if DEBUG then print ("<b>in rclean: obj: "+typeof(@arg1)+" opt: "+@arg2)
-	if arg1 and (typeof(arg1) == "shell" or typeof(arg1) == "ftpshell" or typeof(arg1) == "computer" or typeof(arg1) == "file") then return globals.rclean(arg1,arg2)
+	if arg1 and (typeof(arg1) == "shell" or typeof(arg1) == "ftpshell" or typeof(arg1) == "computer" or typeof(arg1) == "file" or typeof(arg1) == "ftpComputer" or typeof(arg1) == "ftpFile") then return globals.rclean(arg1,arg2)
 	//if arg1 and typeof(arg1.to_int) == "number" then return globals.rclean(command.clipb("@B",arg1),arg2)
 	if arg1 and typeof(arg1.to_int) == "number" then return globals.rclean( globals._ez_clip(["@B",arg1]), arg2)
 	//return globals.rclean(command.clipb("@B","-m"),arg2)
@@ -1928,7 +1928,7 @@ command.ipfit = function(arg1, arg2, arg3=0, arg4=0)
 	if arg1 == "help" or arg1 == "-h" then return "Usage: ipfit -- menu to specify a way to generate ips. (wip)"+char(10)+"Recommendation: pipe the output to a file or to the clipboard."+char(10)+"e.g<b> ipfit | clipb </b>, or<b> ipfit | poke iplist </b>"
 	print("Configuring: ")
 	print("<b>How do you want to specify ip's? </b>"+char(10)+"[0] - enter manually"+char(10)+"[1] - read from file "+char(10)+"[2] - random")
-	print("[3] - specify range"+char(10)+"[4] - from clipb")
+	print("[3] - specify range (Soon)"+char(10)+"[4] - from clipb")
 	choice = user_input("||: ",0,1).to_int
 	ips = []
 	if choice == 0 then

--- a/5hell.5pk.src
+++ b/5hell.5pk.src
@@ -2,7 +2,7 @@
 // released v 4.3.1
 // imports .5pk files from /root/src
 // globals
-ver = "4.3.6_falling_skies"
+ver = "4.3.6.3_falling_skies"
 //print ver
 if not globals.hasIndex("DEBUG") then globals.DEBUG = false // set to true by launching 5hell with --debug as any parameter
 if globals.hasIndex("params") and globals.params.indexOf("--debug") >= 0 then 
@@ -600,7 +600,20 @@ command.ls = function(arg1, arg2, arg3=0, arg4=0)
 	folder = globals.get_file(folderPath)
 	if not folder then return "ls: No such file or directory"
 	if DEBUG then print("folder: "+folder.path+" is a: "+typeof(folder))
-	if folder.is_folder then 
+	output = ""
+	if folder.is_folder then
+		line_color = colorLightBlue+"</b>"
+		nameFile = folder.name
+		permission = folder.permissions
+		owner = folder.owner
+		size = folder.size
+		group = folder.group
+		is_bin = folder.is_binary
+		// if showDetails then
+		// 	output = output + char(10) + line_color + permission + " " + owner + " " + group + " "+ size + " bin["+is_bin+"] " + nameFile + char(10) + colorLightBlue+"|"
+		// else
+		// 	output = output + char(10) + line_color + nameFile + char(10) + colorLightBlue+"|"
+		// end if
 		subFiles = folder.get_folders + folder.get_files
 		if DEBUG then print "debug: pre alpha sort"
 		if a_order then 
@@ -622,7 +635,7 @@ command.ls = function(arg1, arg2, arg3=0, arg4=0)
 	else 
 		subFiles = [folder]
 	end if
-	output = ""
+	//output = ""
 	for subFile in subFiles
 		line_color = colorWhite+"</b>"
 		nameFile = subFile.name
@@ -2743,7 +2756,7 @@ command.purge = function(arg1, arg2, arg3=0, arg4=0)
 		return p.done(l)
 	end function
 	p.t4s = function()
-		l = "Tagged 3 SCP"
+		l = "Tagged 4 SCP"
 		if not p.confirm(l) then return p.a
 		globals.tagged_for_scp = ""
 		return p.done(l)

--- a/5phinx.5pk.src
+++ b/5phinx.5pk.src
@@ -49,7 +49,7 @@ globals.print = function(msg, mode=0, color=0,outfile=0)
     ifdbg = ""
     //if DEBUG then ifdbg = char(10)+"- - - "+time+" - - - "// hahaha, this would be spam hell
     if typeof(log) == "file" and log.has_permission("w") and log.has_permission("r") then 
-      if msg.len + log.get_content.len < 159000 then 
+      if ( msg.len + log.get_content.len) < 159000 then 
         log.set_content(log.get_content+ifdbg+char(10)+msg) 
       else 
         f = log.name.split("\.")
@@ -63,8 +63,8 @@ globals.print = function(msg, mode=0, color=0,outfile=0)
         newspool = globals.get_file(lpp+"/"+nsp)
         globals.spoolpath = newspool.path
         newspool.set_content(msg)
-        print("print: the log has reached the maximum size;"+char(10)+"-- new log file created:"+char(10)+"--: "+newspool.path,0,2)
-        print command.perms("o-rwx",newspool.path) 
+        _print("print: the log has reached the maximum size;"+char(10)+"-- new log file created:"+char(10)+"--: "+newspool.path,0,2)
+        _print command.perms("o-rwx",newspool.path) 
       end if
     else 
       _print(colorError+"<size=75%>print: cannot spool: file path or permission error")
@@ -102,7 +102,8 @@ globals._cascade = function()
 end function
 
 Kérberos = function( sl )
-  if typeof(@sl) == "function" then print colorRed+"</b>Kérberos: prevented rogue function execution" else return @sl 
+  if typeof(@sl) == "function" then print colorRed+"</b>Kérberos: prevented rogue function execution" else return @sl
+  return null
 end function
 
 // no longer used, use the daemon manager instead
@@ -381,29 +382,29 @@ end function
 globals._ez_clip = function( in_prompt )
   for e in in_prompt 
     if DEBUG then print("z: "+@e)
-      // reprocess: unpack single quote chunk, process, repackage
+      // reprocess: unpack single quote chunk, process, repackage. strings only.
     if typeof(@e) != "string" then continue
     if e.split(" ").len > 1 then 
-        in_prompt[in_prompt.indexOf(@e)] = _ez_clip(@e.split(" ")).join(" ")
+        in_prompt[in_prompt.indexOf(e)] = _ez_clip(e.split(" ")).join(" ")
         continue
     end if
     // done reprocessing
     // connecting dots
-    if DEBUG then print("p: "+@e)
-    e_indx = in_prompt.indexOf(@e) 
+    if DEBUG then print("p: "+e)
+    e_indx = in_prompt.indexOf(e) 
     //if @e == "@STOP" then in_prompt[e_indx] = @globals.SAFEWORD
-    if @e == "@a" then in_prompt[e_indx] = @globals.CLIP["a"]
-    if @e == "@b" then in_prompt[e_indx] = @globals.CLIP["b"]
-    if @e == "@c" then in_prompt[e_indx] = @globals.CLIP["c"]
-    if @e == "@home" then 
+    if e == "@a" then in_prompt[e_indx] = @globals.CLIP["a"]
+    if e == "@b" then in_prompt[e_indx] = @globals.CLIP["b"]
+    if e == "@c" then in_prompt[e_indx] = @globals.CLIP["c"]
+    if e == "@home" then 
       command.cob("validate")
       in_prompt[e_indx] = @get_custom_object.HOME.ip
     end if
-    if @e == "@tbuf" then in_prompt[e_indx] = @globals.T_BUF.join(char(10))
-    if @e == "@t" then in_prompt[e_indx] = @globals.targetIP 
-    if @e == "@p" then in_prompt[e_indx] = @str(globals.targetPort)
-    if @e == "@r" then // moar ats! moarats! moar rats!... wait... no, no more rats
-      if in_prompt.hasIndex(e_indx+1) and typeof(in_prompt[e_indx+1]) == "string" then 
+    if e == "@tbuf" then in_prompt[e_indx] = @globals.T_BUF.join(char(10))
+    if e == "@t" then in_prompt[e_indx] = @globals.targetIP 
+    if e == "@p" then in_prompt[e_indx] = @str(globals.targetPort)
+    if e == "@r" then // moar ats! moarats! moar rats!... wait... no, no more rats
+      if in_prompt.hasIndex(e_indx+1) and typeof(@in_prompt[e_indx+1]) == "string" then 
         ind = in_prompt[e_indx+1]
         if ind == "-m" then ind = 0
         tsh = command.rsi("-r",ind)
@@ -417,22 +418,24 @@ globals._ez_clip = function( in_prompt )
         print globals.colorWarning+"<size=75%></b>ezclip: rsi: invalid index"
       end if
     end if
-    if @e == "@o" then
-      if in_prompt.hasIndex(e_indx+1) then//and typeof(in_prompt[e_indx+1]) == "string" and get_custom_object.hasIndex(in_prompt[e_indx+1]) then 
-          get = command.cob("get",in_prompt[e_indx+1])
-          if get != "cob: key not found" then
-            in_prompt[e_indx+1] = command.cob("get",in_prompt[e_indx+1])
-            in_prompt.remove(e_indx)
-          end if
+    if e == "@o" then
+      if in_prompt.hasIndex(e_indx+1) then 
+        print command.cob("get",in_prompt[e_indx+1])
+        if command.cob("get",in_prompt[e_indx+1]) != "cob: key not found" then
+          print "<b>beep boop motherfucker!"
+          in_prompt[e_indx+1] = command.cob("get",in_prompt[e_indx+1])
+          in_prompt.remove(e_indx)
+        end if
       else 
           print globals.colorWarning+"<size=75%></b>ez_clip: cob: key not found"
       end if
+      //continue
     end if
-    if @e == "@B" then 
+    if e == "@B" then 
       b_err = globals.colorWarning+"@BUFFER: invalid selection"
       if in_prompt.hasIndex(e_indx+1) then 
         if DEBUG then print "e_indx: "+e_indx
-        if in_prompt[e_indx+1] == "-m" then 
+        if @in_prompt[e_indx+1] == "-m" then 
           if BUFFER.len == 0 then
             print(globals.colorOrange+"\nBuffer empty. ")
             continue
@@ -470,9 +473,9 @@ globals._ez_clip = function( in_prompt )
               print b_err
           end if
         else
-          if typeof(in_prompt[e_indx+1]) == "string" then 
+          if typeof(@in_prompt[e_indx+1]) == "string" then 
             if globals.BUFFER.hasIndex(in_prompt[e_indx+1].to_int) then 
-                in_prompt[e_indx+1] = @globals.BUFFER[in_prompt[e_indx+1].to_int]
+                in_prompt[e_indx+1] = globals.BUFFER[@in_prompt[e_indx+1].to_int]
                 in_prompt.remove(e_indx)
                 if DEBUG then print "post non menu in_prompt"
             else 
@@ -485,20 +488,20 @@ globals._ez_clip = function( in_prompt )
     // dots connected
     // process escapes
     // hi clover, if you see this, feel free to make it magic
-    if @e == "\@STOP" then in_prompt[e_indx] = "@STOP"
-    if @e == "\@a" then in_prompt[e_indx] = "@a"
-    if @e == "\@b" then in_prompt[e_indx] = "@b"
-    if @e == "\@c" then in_prompt[e_indx] = "@c"
-    if @e == "\""" then in_prompt[e_indx] = """"
-    if @e == "\@home" then in_prompt[e_indx] = "@home"
-    if @e == "\@tbuf" then in_prompt[e_indx] = "@tbuf"
-    if @e == "\@t" then in_prompt[e_indx] = "@t"
-    if @e == "\@p" then in_prompt[e_indx] = "@p"
-    if @e == "\@o" then in_prompt[e_indx] = "@o"
-    if @e == "\@B" then in_prompt[e_indx] = "@B"
-    if @e == "\@r" then in_prompt[e_indx] = "@r"
+    if e == "\@STOP" then in_prompt[e_indx] = "@STOP"
+    if e == "\@a" then in_prompt[e_indx] = "@a"
+    if e == "\@b" then in_prompt[e_indx] = "@b"
+    if e == "\@c" then in_prompt[e_indx] = "@c"
+    if e == "\""" then in_prompt[e_indx] = """"
+    if e == "\@home" then in_prompt[e_indx] = "@home"
+    if e == "\@tbuf" then in_prompt[e_indx] = "@tbuf"
+    if e == "\@t" then in_prompt[e_indx] = "@t"
+    if e == "\@p" then in_prompt[e_indx] = "@p"
+    if e == "\@o" then in_prompt[e_indx] = "@o"
+    if e == "\@B" then in_prompt[e_indx] = "@B"
+    if e == "\@r" then in_prompt[e_indx] = "@r"
     //if @e == "\@pipe" then in_prompt[e_indx] = "@pipe"
-    if DEBUG then print("b: "+ in_prompt[e_indx])
+    if DEBUG then print("b: "+ @in_prompt[e_indx])
     // escapes processed
   end for
   if DEBUG then print "ezclip: returning: "+in_prompt
@@ -581,7 +584,7 @@ string.noparse = function(self)
 end function
 
 // slightly less garbage code than before follows, somehow works
-globals.decompiler = function(o)
+globals.decompiler = function(o,args=0)
     act = "Decompiling"
     if typeof(@o) == "function" then act = "Evaluating"
     if typeof(@o) == "custom_object" then act = "Expanding"
@@ -602,7 +605,7 @@ globals.decompiler = function(o)
     end if
 
     if typeof(@o) == "function" then
-        return p_exe(@o)
+        return p_exe(@o,null,args)
     end if
 
     if typeof(o) == "number" then return "code: cannot decompile a number"
@@ -634,12 +637,22 @@ globals.decompiler = function(o)
             i = i + 1
         end for 
         i = i - 1
-        if DEBUG then print("debug: i: "+i+" methods: "+methods.len)
-        print(colorWhite+"<u>======================</u>"+CT)
-        pr = user_input("Select a function to execute (q=quit):> ").to_int
+        if DEBUG then print "debug: i: "+i+" methods: "+methods.len
+        print colorWhite+"<u>======================</u>"+char(10)+"<b>code: select a method:> "
+
+        pr = null
+        if typeof(args) == "string" then 
+          args = args.split(" ")
+          pr = args[0]
+          args = args[1:]
+        end if
+        if DEBUG then print "<b>debug: pr: </b>"+pr+", <b>args: </b>"+args
+        if not pr then pr = user_input("Select a function to execute (q=quit):> ").to_int
+
         if pr == "q" or pr == "" or pr == " " then return "aborting..." 
+        if methods.indexOf(pr) != null then pr = methods.indexOf(pr)
         rcv = null
-        if pr >= 0 and pr <= i then rcv = globals.p_exe( o , methods[pr]) else return 0
+        if pr >= 0 and pr <= i then rcv = globals.p_exe( o , methods[pr], args) else return "code: index not found"
         if DEBUG then print "rcv: "+rcv
         if rcv then 
             globals.BUFFER.push(rcv)
@@ -651,46 +664,47 @@ globals.decompiler = function(o)
     if typeof(o) == "list" then 
         cw = colorWhite+"</b>"
         cb = colorLightBlue+"</b>"
+        print "<u>"+cw+"ndx"+cb+" : "+cw+"element"
         for d in o
-        print "<u>"+cw+"ndx"+cb+":"+cw+"element"
-        print "["+cw+o.indexOf(d)+CT+"]"+cw+":"+CT+"["+d+"]"
+          print cw+o.indexOf(d)+CT+cw+" : "+CT+"["+d+"]"
         end for
-        print cb+"["+cw+"1</color>] enumerate "+cb+"["+cw+"2</color>] to cob "+cb+"["+cw+"3</color>] to buffer"+char(10)
+        print char(10)+colorGreen+"- - - - - - - - - - - - - -"
+        print cb+"["+cw+"e</color>] enumerate "+cb+"["+cw+"o</color>] to cob "+cb+"["+cw+"x</color>] buffer index"
         print cb+"["+cw+"a</color>] to clipa "+cb+"["+cw+"b</color>] to clipb "+cb+"["+cw+"c</color>]> to clipc"
-        choice = user_input("||: ",0,1)
-        if choice == "1" and command.hasIndex("enum") then 
-          return command.enum(o) 
-        else 
-          globals.enumerated = o 
-          return o 
-        end if
-        if choice == "2" then 
+        print cb+"["+cw+"#</color>] return item at index (single digit)"
+        print cb+"["+cw+"i</color>] prompt for index of item to return (multi digit)"
+        if args then choice = args else choice = user_input("||: ",0,1)
+        if choice == "i" then choice = user_input(colorWhite+"code: select an index:> "+colorLightBlue)
+        if choice.to_int >= 0 and choice.to_int < o.len then return o[choice.to_int]
+        if choice == "e" then return command.enum(o) 
+        if choice == "o" then 
             set_key = user_input("set_key (<b>enter</b>=quit):> ")
             if set_key == "" then print "aborting..."
             return command.cob("set", set_key, o)
         end if
-        if choice == "3" then 
-            tb = user_input("select an index:> ").to_int
+        if choice == "x" then 
+            tb = user_input("list: select an index to send to the BUFFER"+char(10)+":> ").to_int
             if tb < o.len and tb >= 0 then  
-                print "sending element to "+colorOrange+"BUFFER..."
+                print "-- sending element to "+colorOrange+"BUFFER..."
                 globals.BUFFER.push(o[tb])
             else
-                print "invalid index; aborting..."
+                print "-- invalid index; aborting..."
             end if
         end if
         if choice == "a" then return command.clipa(o)
         if choice == "b" then return command.clipb(o)
         if choice == "c" then return command.clipc(o)
+        print "aborting..."
         return 0
     end if
-    out = []
+    out = ""
     for d in o
         out.push(d+char(10))
     end for
-    return 0
+    return o // out
 end function
 
-globals.p_exe = function( obj, f_name=null ) // obj is either game object or function
+globals.p_exe = function( obj, f_name=null, arguments=null ) // obj is either game object or function
   if DEBUG then print("debug: In P_EXE: "+@obj+": "+f_name)
   if typeof(@obj) != "function" and not p_validate(obj, f_name) then return "p_exe: invalid input; expects object or function"
   foo = @obj 
@@ -725,13 +739,15 @@ globals.p_exe = function( obj, f_name=null ) // obj is either game object or fun
             a.push(self_param)
             continue
         end if
-        a.push(obj)
+        a.push(@obj)
         continue 
     end if
     def = ar.split("=")
     if def.len > 1 then def = def[1].trim else def = """"
-
-    inp = user_input("(Use [@a|@b|@c] for the clipboard"+char(10)+"-- ints are cast as ints, use 'int' to cast as string"+char(10)+"<b>enter="+def+"</b>, null=null,  q=quit)"+char(10)+colorLightBlue+"Supply argument for: "+colorWhite+ ar +CT+char(10)+"</b>:> ")
+    inp = null
+    if DEBUG then print "<b>debug: arguments: "+@arguments
+    if typeof(arguments) ==  "list" and arguments.len > 0 then inp = arguments.pull
+    if not @inp then inp = user_input("(Use [@a|@b|@c] for the clipboard"+char(10)+"-- ints are cast as ints, use 'int' to cast as string"+char(10)+"<b>enter="+def+"</b>, null=null,  q=quit)"+char(10)+colorLightBlue+"Supply argument for: "+colorWhite+ ar +CT+char(10)+"</b>:> ")
     if @inp == "q" then return "aborting..."
     if @inp == "" then inp = def
     if @inp == "null" then inp = null
@@ -773,7 +789,7 @@ p_validate = function( o, query=null )
   if test == null then return 0
   if not query then
     if DEBUG then print "debug: no query"
-    o_type = typeof(o) 
+    o_type = typeof(@o) 
     switch(o_type)
     // this uh... doesn't actually do anything....
       if DEBUG then print "debug: switch: start"
@@ -794,15 +810,15 @@ p_validate = function( o, query=null )
       case("debugLibrary",@p_validate(o,"scan"))
       if DEBUG then print "debug: switch: firing default"
     v = default(1)
-    return v
+    return @v
   end if
   if DEBUG then print "debug: query: "+query
   if @o.hasIndex("__isa") and typeof(@o) != "string" then
-    if DEBUG then print colorGreen+"__isa indexes found: "+o.__isa.indexes.len
-    q = o.__isa.hasIndex(query)
+    if DEBUG then print colorGreen+"__isa indexes found: "+@o.__isa.indexes.len
+    q = @o.__isa.hasIndex(query)
     if DEBUG then print "result: "+q
 	  if typeof(@o) == "file" then // hack to make this work for files. testing needed to see if other objects have somethign like this
-      if o.name then return q else return 0
+      if @o.name then return q else return 0
     end if
     return q // does the object have the index we seek?
   else 
@@ -985,20 +1001,6 @@ globals.rsi_purge = function(ktar="ALL")
   for r in rshells
     print colorLightBlue+"rsi: kill "+colorCyan+ktar+"</color> >> "+colorWhite+r.host_computer.public_ip+ " @ "+r.host_computer.local_ip
     print command.kill(ktar,r)
-
-    // processes = r.host_computer.show_procs.split(char(10))
-    // for p in processes
-    //   if p == "USER PID CPU MEM COMMAND" then continue
-    //   process = p.split(" ")
-    //   process_ID = process[1]
-    //   process_CMD = process[4]
-    //   if process_CMD != exclude then 
-    //     print "Killing: "+process_CMD+" ID: "+process_ID
-    //     print r.host_computer.close_program(process_ID.to_int)
-    //   else 
-    //     print "rsi: excluding "+exclude+" from purge..."
-    //   end if
-    // end for
   end for
   return 0
 end function
@@ -3204,13 +3206,13 @@ end function
 load_lib = function(lib_path)
   if DEBUG then print "load_lib_path: "+lib_path
   if lib_path.len < 1 then return "aborting..."
-  print "meta: clearing metaLib and net_session..."
+  print colorGold+"meta: clearing metaLib and net_session..."
   globals.metaLib = null 
   globals.net_session = null // clear out net_session since we are working with a local lib
   new_lib = metaxploit.load(lib_path)
   if not new_lib then new_lib = metaxploit.load("/lib/"+lib_path)
   if new_lib then
-    print "metaLib: linking "+colorLightBlue+new_lib.lib_name+"<color=blue> v </color>"+new_lib.version+char(10)
+    print "metaLib: linking "+colorLightBlue+new_lib.lib_name+colorDarkBlue+" v </color>"+new_lib.version+char(10)
     globals.metaLib = new_lib
   else
     print colorOrange+"load_lib: file not found or not a library "

--- a/5phinx.5pk.src
+++ b/5phinx.5pk.src
@@ -1,9 +1,9 @@
 // Sphinx Hacking Interface v 3.2 by Plu70
 
 //Define Globals
-sphinx_version = "3.3.9"
-malp_version = "1.6.6"
-if DEBUG then print("<size=75%>loading 5phinx.5pk v "+sphinx_version+" for 5hell v 4.3.6...(155.924)")
+sphinx_version = "3.4.0"
+malp_version = "1.6.7"
+if DEBUG then print("<size=75%>loading 5phinx.5pk v "+sphinx_version+" for 5hell v 4.3.7...(157.992)")
 
 NUM_SPLOITS = function()
   num = globals.XPLOITS.len
@@ -458,7 +458,10 @@ globals._ez_clip = function( in_prompt )
             end if
             if typeof(@b) == "file" then print(b.path+char(10)+b.permissions+" "+b.owner+" "+b.group+" "+b.size+" b["+b.is_binary+"] "+b.name)
             if typeof(@b) == "computer" then print(format_columns(b.show_procs+char(10)+b.public_ip+char(10)+b.local_ip))
-            if typeof(@b) == "shell" or typeof(@b) == "ftpshell" then print(format_columns(b.host_computer.show_procs+char(10)+b.host_computer.public_ip+char(10)+b.host_computer.local_ip))
+            if typeof(@b) == "shell" then print(format_columns(b.host_computer.show_procs+char(10)+b.host_computer.public_ip+char(10)+b.host_computer.local_ip))
+            if typeof(@b) == "ftpshell" then print format_columns("cname: "+b.host_computer.get_name)
+            if typeof(@b) == "ftpComputer" then print format_columns("cname: "+b.get_name)
+            if typeof(@b) == "ftpFile" then print format_columns(b.path)
             if typeof(@b) == "string" or typeof(@b) == "list" or typeof(@b) == "map" then print( "elements: "+b.len )
             i = i + 1
           end for
@@ -782,7 +785,7 @@ end function
 
 p_validate = function( o, query=null )
   if DEBUG then print "DEBUG: in p_validate"+char(10)+"validating: "+@o
-  if typeof(@o) == "number" or typeof(@o) == "string" or not @o.hasIndex("__isa") then return 1
+  if not @o or typeof(@o) == "number" or typeof(@o) == "string" or not @o.hasIndex("__isa") then return 1
   methods = o.__isa.indexes
   if methods.len < 2 then return 0
   test = new @o 
@@ -793,8 +796,8 @@ p_validate = function( o, query=null )
     switch(o_type)
     // this uh... doesn't actually do anything....
       if DEBUG then print "debug: switch: start"
-      case("ftpshell",@p_validate(o,"start_terminal"))
-      case("shell",@p_validate(o,"start_terminal"))
+      case("ftpshell",@p_validate(o,"host_computer"))
+      case("shell",@p_validate(o,"host_computer"))
       case("computer",@p_validate(o,"get_name"))
       case("file",@p_validate(o,"name"))
       case("MetaLib",@p_validate(o,"version"))
@@ -1077,8 +1080,12 @@ secure_copy = function(shl,copy_to=0,trajectory=-1,skip_perms=0)
   active_s = colorCyan+"</b>"+localmachine.local_ip+" @ <b>"+localmachine.public_ip+CT
   target_s = colorOrange+"pshell"+CT
   if p_validate(shl, "host_computer") then
-    target_s = colorOrange+"</b>"+shl.host_computer.local_ip+" @ <b>"+shl.host_computer.public_ip+CT
-    if shl.host_computer.local_ip == localmachine.local_ip and shl.host_computer.public_ip == localmachine.public_ip then active_s = colorOrange+"</b>"+localmachine.local_ip+" @ <b>"+localmachine.public_ip+CT
+    if p_validate(shl.host_computer,"local_ip") then
+      target_s = colorOrange+"</b>"+shl.host_computer.local_ip+" @ <b>"+shl.host_computer.public_ip+CT
+      if shl.host_computer.local_ip == localmachine.local_ip and shl.host_computer.public_ip == localmachine.public_ip then active_s = colorOrange+"</b>"+localmachine.local_ip+" @ <b>"+localmachine.public_ip+CT
+    else
+      target_s = colorOrange+"</b>"+shl.host_computer.get_name+CT
+    end if
   else 
     return colorError+"scp: target shell has been invalidated"
   end if
@@ -1098,16 +1105,17 @@ secure_copy = function(shl,copy_to=0,trajectory=-1,skip_perms=0)
   if DEBUG then print "debug: udp is "+udp+" and is a "+typeof(udp)
   if udp == "q" then return
   if udp == "1" then
+    //if typeof(shl) == "ftpshell" then return colorError+"</b>scp: error; a game bug prevents ftpshell.put from functioning"//shl.put(copy_from, copy_to, globals.shell) ///////// copying
     if typeof(shl) == "shell" or typeof(shl) == "ftpshell" or typeof(shl) == "pshell" then
       targ_f = shl.host_computer.File(copy_from)
       if targ_f then
-        print("scp: pulling "+targ_f.path+" from "+shl.host_computer.local_ip+" @ "+shl.host_computer.public_ip)
+        if typeof(shl) == "shell" then to_shl = shl.host_computer.local_ip+" : "+shl.host_computer.public_ip else to_shl = typeof(shl)
+        print "scp: pulling "+targ_f.path+" from: <b>"+copy_from+" @ " +to_shl
       else
         return colorOrange+"scp-download: "+copy_from +" not found"
       end if
       if not targ_f.has_permission("r") then return "scp: copy permission denied"
-      if typeof(shl) == "shell" then return shl.scp(copy_from, copy_to, globals.shell) ///////// copying
-      if typeof(shl) == "ftpshell" then return colorError+"</b>scp: error; a game bug prevents ftpshell.put from functioning"//shl.put(copy_from, copy_to, globals.shell) ///////// copying
+      if typeof(shl) == "shell" or typeof(shl) == "ftpshell" then return shl.scp(copy_from, copy_to, globals.shell) ///////// copying
       if typeof(shl) == "pshell" and p_validate(shl,"scp") then return shl.scp(copy_from, copy_to, globals.shell) else return colorWarning+"scp: p_object; invalid object or no scp function"///////// copying
       return "aborting..."
     end if
@@ -1135,7 +1143,8 @@ secure_copy = function(shl,copy_to=0,trajectory=-1,skip_perms=0)
         if mod.lower == "q" then return "aborting..."
         print(char(10)+"<b>Upload Ready: "+payload.path + " " + payload.size + " " + payload.permissions+"</b>"+char(10))
         failed = false
-        print("scp: pushing "+payload.path+" to "+copy_to+" @ "+shl.host_computer.local_ip+" : "+shl.host_computer.public_ip)
+        if typeof(shl) == "shell" then to_shl = shl.host_computer.local_ip+" : "+shl.host_computer.public_ip else to_shl = typeof(shl)
+        print "scp: pushing "+payload.path+" to: "+copy_to+" @ "+to_shl // shl.host_computer.local_ip+" : "+shl.host_computer.public_ip
         print(shell.scp(payload.path, copy_to, shl)) ///// copying
         if copy_to == "/" then copy_to = ""
         if not shl.host_computer.File(copy_to+"/"+payload.name) then failed = true else globals.tagged_for_scp == ""
@@ -1153,7 +1162,9 @@ secure_copy = function(shl,copy_to=0,trajectory=-1,skip_perms=0)
         end if
         if failed then return "scp: failed" else return "scp complete: "+payload.path + " " + payload.size + " " + payload.permissions+char(10)+"-- copied to: "+copy_to+"/"+payload.name
       else
-        if typeof(globals.shell) == "ftpshell" then print colorRed+"</b>scp: error; a game bug prevents ftpshell.put from working"+char(10)+"-- aborting..." else print "aborting..." //print(shell.put(copy_from, copy_to, shl)) else return "aborting..." ///// copying
+        //if typeof(globals.shell) == "ftpshell" then print colorRed+"</b>scp: error; a game bug prevents ftpshell.put from working"+char(10)+"-- aborting..." else print "aborting..."
+        print colorLightBlue+"GLASSPOOL FTP:"
+        print(shell.scp(copy_from, copy_to, shl))
         return "scp complete: "+payload.path + " " + payload.size + " " + payload.permissions+char(10)+"-- copied to: "+copy_to+"/"+payload.name
       end if
     end if
@@ -1628,7 +1639,9 @@ globals.memory_alpha = function(go_to_buffer=false,go_to_selection=null)
         end if
         if typeof(@b) == "file" then print(b.path+char(10)+b.permissions+" "+b.owner+" "+b.group+" "+b.size+" b["+b.is_binary+"] "+b.name)
         if typeof(@b) == "computer" then print(format_columns(b.show_procs+char(10)+b.public_ip+char(10)+b.local_ip))
-        if typeof(@b) == "shell" or typeof(@b) == "ftpshell" then print format_columns(b.host_computer.show_procs+char(10)+b.host_computer.public_ip+char(10)+b.host_computer.local_ip)
+        if typeof(@b) == "shell" then print format_columns(b.host_computer.show_procs+char(10)+b.host_computer.public_ip+char(10)+b.host_computer.local_ip)
+        if typeof(@b) == "ftpshell" then print format_columns("cname: "+b.host_computer.get_name)
+        if typeof(@b) == "ftpComputer" then print format_columns("cname: "+b.get_name)
         if typeof(@b) == "list" or typeof(@b) == "map" then print "elements: "+b.len
         if @b isa string then
           print "elements: <b>"+b.len
@@ -1841,24 +1854,24 @@ globals.memory_alpha = function(go_to_buffer=false,go_to_selection=null)
           notftp = true 
           if typeof(buffer_selection) == "ftpshell" then notftp = false
           while shelling == true
-            print(colorOrange+"<mark=orange><u>= = = = = = = = = = = = = = =</u></mark>"+CT)
-            print(format_columns(buffer_selection.host_computer.show_procs)+char(10)+char(10)+checkUser(buffer_selection)+"@"+buffer_selection.host_computer.local_ip+char(10)+buffer_selection.host_computer.public_ip)
-            print(colorOrange+"<size=65%><mark=orange><u>= = = = = = = = = = = = = = = = = = = =</u></mark></size>"+CT)
-            print   "[f] felix  [c] curl       [p] purge from buffer"
+            print(colorOrange+"<mark=orange><u>= = = = = = = = = = = = = = =</u></mark>")
+            if notftp then print format_columns(buffer_selection.host_computer.show_procs)+char(10)+char(10)+checkUser(buffer_selection)+"@"+buffer_selection.host_computer.local_ip+char(10)+buffer_selection.host_computer.public_ip else print typeof(buffer_selection)+": "+checkUser(buffer_selection)+"@"+buffer_selection.host_computer.get_name
+            print colorOrange+"<size=65%><mark=orange><u>= = = = = = = = = = = = = = = = = = = =</u></mark></size>"
+            print   "[f] felix  [c] curl      [p] purge from buffer"
             if typeof(buffer_selection) == "shell" then 
-              print "[7] scp    [8] run        [9] fetch meta" +char(10)+
-                    "[4] glassp [5] rclean     [6] get computer "+char(10)+
-                    "[1] open   [2] redirect   [3] upload rkit"
+              print "[7] scp    [8] run       [9] fetch meta" +char(10)+
+                    "[4] glassp [5] rclean    [6] get computer "+char(10)+
+                    "[1] open   [2] redirect  [3] upload rkit"
             end if                             
             if typeof(buffer_selection) == "ftpshell" then 
-              print "[4] glassp [5] rclean     [6] get computer"
-              print "[1] open   [2] scp/put    [3] upload rkit"
+              print "           [5] rclean    [6] get computer"
+              print "[1] get/put (scp)        [3] put rkit"
             end if
-            print   "[0] to cob [d] decompile  [b] fetch binaries"
+            print   "[0] to cob [d] decompile [b] fetch binaries"
             choice = user_input("(q=quit)||: ",0,1)
             if choice == "0" then 
               print colorOrange+"cobbling..."
-              keyword = user_input("Enter custom_object key  for shell [q=quit]:> ")
+              keyword = user_input("Enter custom_object key for "+typeof(buffer_selection)+" (q=quit):> ")
               if keyword.lower == "q" then 
                 print "aborting..."
                 continue 
@@ -1885,7 +1898,7 @@ globals.memory_alpha = function(go_to_buffer=false,go_to_selection=null)
             end if
             if choice == "p" then 
               print command.purge("-b",str(selection))
-              print colorOrange+"Shell object purged from BUFFER"
+              print colorOrange+typeof(buffer_selection)+" object purged from BUFFER"
               continue 
             end if
             if choice == "d" then 
@@ -1942,27 +1955,32 @@ globals.memory_alpha = function(go_to_buffer=false,go_to_selection=null)
               continue
             end if
             if choice == "4" then
-              print command.glasspool(buffer_selection)
+              if notftp then print command.glasspool(buffer_selection) else print colorOrange+"sorry: ftpshells and ftpComputers are not currently compatible with glasspool"
               continue
             end if
-            if choice == "7" and notftp then 
+            if choice == "7" then 
               print secure_copy(buffer_selection)
               continue 
             end if
             if choice == "3" then 
-              print command.infil(buffer_selection)
+              print command.infil(buffer_selection) 
               continue 
             end if
             if choice == "1" then
-              print("Opening a terminal will exit "+CT+colorRed+"5hell"+CT+". Continue? ")
-              if user_input("[<b>Y</b>/n] :>").lower == "n" then continue
-              if typeof(buffer_selection) == "shell" then
-                print(colorWhite+"-ssh---"+buffer_selection.host_computer.public_ip+"-----------"+CT+char(10))
+              if notftp then
+                print("Opening a terminal will exit "+CT+colorRed+"5hell"+CT+". Continue? ")
+                if user_input("[<b>Y</b>/n] :>").lower == "n" then continue
+                if typeof(buffer_selection) == "shell" then
+                  print(colorWhite+"-ssh---"+buffer_selection.host_computer.public_ip+"-----------"+CT+char(10))
+                else
+                  print(colorWhite+"-ftp---"+buffer_selection.host_computer.public_ip+"-----------"+CT+char(10))
+                end if
+                //get_custom_object.return_value = "#!#CASCADE#!#"
+                buffer_selection.start_terminal
               else
-                print(colorWhite+"-ftp---"+buffer_selection.host_computer.public_ip+"-----------"+CT+char(10))
+                print "Opening SCPM for FTP:"
+                print globals.secure_copy(buffer_selection)
               end if
-              //get_custom_object.return_value = "#!#CASCADE#!#"
-              buffer_selection.start_terminal
               continue
             end if
             if choice == "2" then 
@@ -1981,7 +1999,8 @@ globals.memory_alpha = function(go_to_buffer=false,go_to_selection=null)
           print "Expanding: "+typeof(@buffer_selection)+"..."
           print "["+colorWhite+"c"+CT+"] add to custom object"
           print "["+colorWhite+"d"+CT+"] send to decompiler"
-          uip = user_input("(anything else = quit) :>")
+          print "- - - - - - - - - - - - "
+          uip = user_input("(anything_else = quit)"+colorWhite+":> ")
           if uip == "d" then 
             print(globals.decompiler(@buffer_selection))
             continue 
@@ -2030,7 +2049,7 @@ end function
 ///////////////////////////////////// END MEMORY ALPHA ///////////////////////////
 
 globals.newtree = function(a_file,quiet=0)
-  if typeof(a_file) != "file" then return "tree: invalid type"
+  if typeof(a_file) != "file" and typeof(a_file) != "ftpFile" then return "tree: invalid type"
   system_map = {}
 
   listFiles = function(f)
@@ -2167,7 +2186,7 @@ globals.rclean = function(arg1, arg2=0)
   detection_factor = 0
   if DEBUG then print "debug: arg1: "+arg1+ "arg2: "+arg2
   remote_clean = function(f,d=0) // file object, bool 0|1
-    if typeof(f) != "file" then return "Error. Expected file got: "+f
+    if typeof(f) != "file" and typeof(f) != "ftpFile" then return "Error. Expected file got: "+f
     if not f.has_permission("r") then return "Error: scrub failed. no read permissions."
     catch = colorRed+"Log wipe failed."+CT
     rooting = true
@@ -2182,11 +2201,11 @@ globals.rclean = function(arg1, arg2=0)
     sys = null
     log = command.tree(f, "system.log", 1, "N")
     sys = command.tree(f, "silentclean", 1, "N") 
-    if not log then return "rclean: system.log not found. aborting."
+    if typeof(log) != "file" and typeof(log) != "ftpFile" then return "rclean: system.log not found. aborting."
     if not log.has_permission("w") then return "rclean: cannot write to /var/system.log: permission denied"
     if DEBUG then print "debug: log is a "+typeof(log)+char(10)+"debug: sys is a "+typeof(sys)
-    if typeof(sys) != "file" or d == "-d" or d == "-n" then sys = command.tree(f, "xorg.conf", 1, "N")
-    if typeof(sys) != "file" then  
+    if ( typeof(sys) != "file" and typeof(sys) != "ftpFile" ) or d == "-d" or d == "-n" then sys = command.tree(f, "xorg.conf", 1, "N")
+    if typeof(sys) != "file" and typeof(sys) != "ftpFile" then  
       print "rclean: could not find a file named silentclean or xorg.conf on system" 
       sys = command.tree(f,user_input("rclean: "+colorCyan+"please enter a filename that exists on the system"+char(10)+"-- rclean will use this file for scrubbing"+char(10)+"(q=quit) FileName:> "),1,"N")
       if not sys then return "rclean: failed: no scrub file"
@@ -2256,11 +2275,11 @@ globals.rclean = function(arg1, arg2=0)
     t_shell = arg1
     t_file = t_shell.host_computer.File("/")
   else
-    if typeof(arg1) == "computer" then
+    if typeof(arg1) == "computer" or typeof(arg1) == "ftpComputer" then
       t_comp = arg1
       t_file = t_comp.File("/")
     else
-      if typeof(arg1) == "file" then
+      if typeof(arg1) == "file" or typeof(arg1) == "ftpFile" then
         t_file = arg1
       end if
     end if

--- a/contrib.5pk.src
+++ b/contrib.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading contrib.5pk for 5hell v 4.3.6...(77.323)")
+if DEBUG then print("<size=75%>loading contrib.5pk for 5hell v 4.3.7...(77.394)")
   
  //////////////////////contrubutions start here///////////
   /// this is stuff that was not made entirely by Plu70
@@ -1047,8 +1047,8 @@ command.glosure = function(arg1, arg2=0, arg3=0, arg4=0)
     rfile = null
     file = null
     if result == null then return "null"
-    if typeof(result) != "shell" and typeof(result) != "ftpshell" and typeof(result) != "file" and typeof(result) != "computer" then return "???"
-    if typeof(result) == "computer" then
+    if typeof(result) != "shell" and typeof(result) != "ftpshell" and typeof(result) != "file" and typeof(result) != "computer" and typeof(result) != "ftpComputer" then return "???"
+    if typeof(result) == "computer" or typeof(result) == "ftpComputer" then
       file = result.File("/home")
       rfile = result.File("/")
     else if typeof(result) == "shell" or typeof(result) == "ftpshell" then

--- a/dtools.5pk.src
+++ b/dtools.5pk.src
@@ -172,8 +172,8 @@ command.cob = function(arg1,arg2,arg3=0,arg4=0)
 	end function
 	cob._inspectible = function(tmpc)
 		if DEBUG then print "is_inspectibible: "+@tmpc
-		if typeof(@tmpc) == "function" or typeof(tmpc) == "number" or typeof(tmpc) == "string" then return 0
-		if typeof(tmpc) == "list" or typeof(tmpc) == "map" then return 1
+		if typeof(@tmpc) == "function" or typeof(@tmpc) == "number" or typeof(@tmpc) == "string" then return 0
+		if typeof(@tmpc) == "list" or typeof(@tmpc) == "map" then return 1
 		if not tmpc then return 0
 		if tmpc.hasIndex("classID") then return 1
 		return 0
@@ -283,14 +283,14 @@ command.cob = function(arg1,arg2,arg3=0,arg4=0)
 		end if
 	end function
 
-	if arg1 == "return" then return cobble
-	if arg1 == "validate" then return cob.validate
-	if arg1 == "reset" then return cob.reset
-	if arg1 == "install" then 
+	if @arg1 == "return" then return cobble
+	if @arg1 == "validate" then return cob.validate
+	if @arg1 == "reset" then return cob.reset
+	if @arg1 == "install" then 
 		if typeof(@arg2) == "string" then return cob.install(arg2) else return "cob: install expects a (string: key) from the custom object"
 	end if
 
-	if arg1 == "set" then
+	if @arg1 == "set" then
 		if not @arg2 then return "cob: index cannot be zero or null"
 		if @arg3 then
 			if @arg2 == "@clipa" then arg2 = @globals.CLIP["a"]
@@ -319,7 +319,7 @@ command.cob = function(arg1,arg2,arg3=0,arg4=0)
 			return "cob: invalid input; <size=75%>use <b>@z</b> for zero and <b>@n</b> for null"+char(10)+"<size=75%>-- escape with \@z, \@n"
 		end if
 	end if
-	if arg1 == "get" or arg1 == "del" then
+	if @arg1 == "get" or @arg1 == "del" then
 		if not @arg2 then return cob.err
 		kl = []
 		rl = []
@@ -335,30 +335,30 @@ command.cob = function(arg1,arg2,arg3=0,arg4=0)
 			rl.push(@got)
 			if cob._inspectible(@rl[-1]) then 
 				last_c = cobble
-				cobble = rl[-1]
+				cobble = @rl[-1]
 			else
 				brok = 1
 				break
 			end if
 		end for
-		if arg1 == "del" then
+		if @arg1 == "del" then
 			if not brok then cobble = last_c
 			return cob.del(@kl[-1])
 		end if
-		return rl[-1]
+		return @rl[-1]
 	end if
-	if arg1 == "push" then return cob._push(@arg2,@arg3)
-	if arg1 == "indexes" then return cob.return_indexes
-	if arg1 == "inspect" then return cob.inspect(@arg2)
-	if arg1 == "sign" then return cob.sign(signature)
-	if arg1 == "search" then
+	if @arg1 == "push" then return cob._push(@arg2,@arg3)
+	if @arg1 == "indexes" then return cob.return_indexes
+	if @arg1 == "inspect" then return cob.inspect(@arg2)
+	if @arg1 == "sign" then return cob.sign(signature)
+	if @arg1 == "search" then
 		if @arg2 then return cob.search( @arg2 ) else return cob.err
 	end if
 	// if arg1 == "del" then
 	// 	if @arg2 == "macros.classID" or arg2 == "HOME.classID" then return "cob: "+arg2+" is a protected value"
 	// 	if @arg2 then return cob.del( @arg2 ) else return cob.err
 	// end if
-	if arg1 == "purge" then return command.purge("-o","y")
+	if @arg1 == "purge" then return command.purge("-o","y")
 	return cob.err
 end function
 command.poke = function(arg1, arg2, arg3=0, arg4=0)
@@ -3180,11 +3180,12 @@ command.code = function(arg1, arg2, arg3=0, arg4=0)
 		if DEBUG then print "debug: code: string buf: "+buf
 		return buf.join(", ")
 	end if
-	if typeof(@arg1) == "shell" or typeof(@arg1) == "ftpshell" or typeof(@arg1) == "file" or typeof(@arg1) == "computer" or typeof(@arg1) == "map" or typeof(@arg1) == "custom_object" or typeof(@arg1) == "list" then return globals.decompiler(@arg1)
-	if typeof(@arg1) == "pshell" or typeof(@arg1) == "pcomputer" or typeof(@arg1) == "pfile" or typeof(@arg1) == "prouter" then return globals.decompiler(@arg1)
-	if @arg1.hasIndex("__isa") then return globals.decompiler(@arg1)
+	if DEBUG then print "<b>debug: preparing to send "+@arg1+" to decompiler with args: "+arg2
+	if typeof(@arg1) == "shell" or typeof(@arg1) == "ftpshell" or typeof(@arg1) == "file" or typeof(@arg1) == "computer" or typeof(@arg1) == "map" or typeof(@arg1) == "custom_object" or typeof(@arg1) == "list" then return globals.decompiler(@arg1,arg2)
+	if typeof(@arg1) == "pshell" or typeof(@arg1) == "pcomputer" or typeof(@arg1) == "pfile" or typeof(@arg1) == "prouter" then return globals.decompiler(@arg1,arg2)
+	if @arg1.hasIndex("__isa") then return globals.decompiler(@arg1,arg2)
 	check = new @arg1 
-	if typeof(@check) == "map" then return globals.decompiler(@arg1)
+	if typeof(@check) == "map" then return globals.decompiler(@arg1,arg2)
 	return "code: unkown type"
 end function
 command.silentclean = function(arg1=0, arg2=0, arg3=0, arg4=0)

--- a/dtools.5pk.src
+++ b/dtools.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading dtools.5pk v 4.3.6...(158.054)")
+if DEBUG then print("<size=75%>loading dtools.5pk v 4.3.7...(158.249)")
 
 command.cob = function(arg1,arg2,arg3=0,arg4=0)
 	cy = colorCyan 
@@ -950,8 +950,8 @@ command.tree = function(arg1, arg2=0, arg3=0, arg4=0)
 		if arg1 == "@clipc" or arg1 == "@c" then arg1 = globals.CLIP["c"]
 		if typeof(arg1) == "string" then tem = globals.get_file(arg1)
 		if typeof(arg1) == "shell" or typeof(arg1) == "ftpshell" then tem = arg1.host_computer.File("/")
-		if typeof(arg1) == "computer" then tem = arg1.File("/")
-		if typeof(arg1) == "file" then tem = arg1
+		if typeof(arg1) == "computer" or typeof(arg1) == "ftpComputer" then tem = arg1.File("/")
+		if typeof(arg1) == "file" or typeof(arg1) == "ftpFile" then tem = arg1
 	else
 		tem = localmachine.File("/")
 	end if

--- a/help.5pk.src
+++ b/help.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading help.5pk v 4.3.6...(132.266)")
+if DEBUG then print("<size=75%>loading help.5pk v 4.3.7...(132.266)")
 
 command.help = function(arg1, arg2, arg3=0, arg4=0)
 	if arg1 == "help" or arg1 == "-h" then return "helping..."

--- a/kore.5pk.src
+++ b/kore.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading kore.5pk v 4.3.6...(75.254)")
+if DEBUG then print("<size=75%>loading kore.5pk v 4.3.7...(75.839)")
 command.kore = function(arg1,arg2=0,arg3=0,arg4=0)
     time_s = time
     kore_usage_info = "<u>"+colorGold+"KORE 3.0 || automation || helper || Goddess of the DEAD and GRAIN || rkit || security"+char(10)+char(10)+
@@ -1098,7 +1098,7 @@ command.glasspool = function(arg1,arg2,arg3,arg4)
 	if obj == "-m" then 
 		temp_buf = []
 		for b in globals.BUFFER
-			if typeof(b) == "shell" or typeof(b) == "ftpshell" or typeof(b) == "computer" then temp_buf.push(b)
+			if typeof(b) == "shell" or typeof(b) == "ftpshell" or typeof(b) == "computer" or typeof(b) == "ftpComputer" then temp_buf.push(b)
 		end for
 		r_index = temp_buf.len
 		if metaxploit then
@@ -1113,13 +1113,19 @@ command.glasspool = function(arg1,arg2,arg3,arg4)
 		active_icon = "<b> - </b>"
 		for tb in temp_buf
 			if ti >= r_index then color_shelle = colorLightBlue // color rshells blue
-			if typeof(tb) == "shell" or typeof(tb) == "ftpshell" then
+			if typeof(tb) == "shell" then // or typeof(tb) == "ftpshell" then
 				if tb.host_computer.public_ip == globals.shell.host_computer.public_ip and tb.host_computer.local_ip == globals.shell.host_computer.local_ip then active_icon = colorCyan+" * "+CT
 				p_ip = tb.host_computer.public_ip
 				l_ip = tb.host_computer.local_ip
-			else 
+			else if typeof(tb) == "computer" then
 				p_ip = tb.public_ip
 				l_ip = tb.local_ip
+			else if typeof(tb) == "ftpshell" then
+				l_ip = checkUser(tb)
+				p_ip = tb.host_computer.get_name
+			else
+				l_ip = checkUser(tb)
+				p_ip = tb.get_name
 			end if
 			she_buf.push("["+colorWhite+ti+CT+"]"+active_icon+""+color_shelle+"["+checkUser(tb)+":"+typeof(tb)+"] "+CT+l_ip+" @ <b>"+p_ip+"</b>") 
 			active_icon = "<b> - </b>" // reset active icon
@@ -1146,11 +1152,11 @@ command.glasspool = function(arg1,arg2,arg3,arg4)
 		end if
 	end if
 	// check result. file objects are not supported at this time
-	if typeof(obj) != "shell" and typeof(obj) != "computer" then return "glasspool: expects shell or computer"
+	if typeof(obj) != "shell" and typeof(obj) != "computer" then return "glasspool: expects shell or computer" // ftpshells/computers are jank and don't include local and public ip so... no
 	print(colorLightBlue+"<size=75%>Initializing sshfs glasspool protocol..."+CT)
 
 	// -- handle shell
-	if typeof(obj) == "shell" then
+	if typeof(obj) == "shell" then //or typeof(obj) == "ftpshell" then
 		// save current state
 		hold_shell = globals.shell
 		globals.shell = obj
@@ -1165,7 +1171,8 @@ command.glasspool = function(arg1,arg2,arg3,arg4)
 			"<size=75%>---- will execute on the machine attached to the shell object"+char(10)+
 			"<size=75%>-- <b>local/general</b> category commands will execute on the local machine"+char(10)+
 			"<size=75%>-- <b>tab completion</b> does not translate through glasspool"
-			if typeof(globals.shell) == "ftpshell" then print colorOrange+"<size=75%>Warning: ftp shells have limited functionality"
+			if typeof(globals.shell) == "ftpshell" then print colorOrange+"<size=75%>Warning: ftp shells have limited functionality"+char(10)+"-- please report any crashes to Plu70"
+			print
 			// print("Type: <b><u>return</u></b> to deactivate and return. Exit to quit completely.")
 			// switch scope
 			uu = checkUser(globals.shell)
@@ -1186,19 +1193,19 @@ command.glasspool = function(arg1,arg2,arg3,arg4)
 			globals.GLASSPOOL = globals.GLASSPOOL - 1
 			// update path
 			globals.update_path(temp_p)
-			print(colorLightBlue+"<size=75%>glasspool: "+colorOrange+" deactivating..."+CT)
+			print colorLightBlue+"<size=75%>glasspool: "+colorOrange+" deactivating..."
 		else
 			globals.shell = hold_shell
 			globals.localmachine = globals.shell.host_computer
-			print(colorOrange+"<size=75%>glasspool: error: failed to initialize."+CT)
+			print colorOrange+"<size=75%>glasspool: error: failed to initialize."
 		end if
 	end if
 
 	// -- handle computer
-	if typeof(obj) == "computer" then
+	if typeof(obj) == "computer" then //or typeof(obj) == "ftpComputer" then
 		// display info/warning.
 
-		print(colorLightBlue+"<size=75%>glasspool: initializing glass puddle computer handler...")+CT
+		print colorLightBlue+"<size=75%>glasspool: initializing glass puddle computer handler..."
 		// save current state
 		tem_c = globals.localmachine
 		globals.localmachine = obj
@@ -1209,7 +1216,9 @@ command.glasspool = function(arg1,arg2,arg3,arg4)
 			colorOrange+"<size=75%>glasspool: computer mirroring:"+char(10)+
 			"<size=75%>-- <color=yellow>computer</color>, and <color=yellow>file</color> commands"+char(10)+
 			"<size=75%>---- will execute on the machine connected to the computer object"+char(10)+
-			"<size=75%>-- <color=yellow>shell</color> and <b>local/general commands</b> will execute on the local machine"+char(10)
+			"<size=75%>-- <color=yellow>shell</color> and <b>local/general commands</b> will execute on the local machine"
+			if typeof(globals.shell) == "ftpshell" then print colorOrange+"<size=75%>Warning: ftp shells have limited functionality"+char(10)+"-- please report any crashes to Plu70"
+			print
 			// switch scope
 			uu = checkUser(globals.localmachine)
 			if DEBUG then print "debug: uu: "+uu
@@ -1228,10 +1237,10 @@ command.glasspool = function(arg1,arg2,arg3,arg4)
 			// update path
 			globals.update_path(temp_p)
 			globals.GLASSPOOL = globals.GLASSPOOL - 1
-			print(colorLightBlue+"GLASS_PUDDLE: "+colorOrange+" deactivating..."+CT)
+			print colorLightBlue+"GLASS_PUDDLE: "+colorOrange+" deactivating..."
 		else 
 			globals.localmachine = tem_c
-			print(colorOrange+"glasspool: error: failed to initialize."+CT)
+			print colorOrange+"glasspool: error: failed to initialize."
 		end if
 	end if
 	return 0
@@ -1285,16 +1294,16 @@ command.outmon = function(arg1,interval=2, act=0, react=0)
 	    //skip
 	  else
 	    last_read = out_space.get_content
-		print(colorWhite+"daemon: "+daemon+CT)
-	    print(colorGreen+"///////////////////////////////////////"+CT)
-	    print(last_read)
-	    print(colorGreen+"///////////////////////////////////////"+CT)
+		print colorWhite+"daemon: "+daemon
+	    print colorGreen+"///////////////////////////////////////"
+	    print last_read
+	    print colorGreen+"///////////////////////////////////////"
 		if act == 1 then manager.Stop(daemon)
 		if act == 2 then print command.do("1",last_read)
 		if act == 3 then print command.do("1",react)
-		print(colorWhite+"Listening on :"+out_space.path+" for connections..."+CT)
+		print colorWhite+"Listening on :"+out_space.path+" for connections..."
 	  end if
-	  wait(interval)
+	  wait interval
 	end while
 	return 0
 end function

--- a/net.5pk.src
+++ b/net.5pk.src
@@ -454,10 +454,14 @@ command.ifconfig = function(arg1=0, arg2=0, arg3=0, arg4=0)
 	globals.pubip = globals.localmachine.public_ip
 	use_comp = globals.localmachine
 
-	if typeof(arg1) == "shell" or typeof(arg1) == "computer" or typeof(arg2) == "shell" or typeof(arg2) == "computer" then
-		use_comp = arg2
-		if typeof(arg2) == "shell" then use_comp == arg2.host_computer
+	if typeof(arg1) == "shell" or typeof(arg1) == "computer" then 
+		if typeof(use_comp) == "shell" then use_comp == use_comp.host_computer else use_comp = arg1
 	end if
+	
+	if typeof(arg2) == "shell" or typeof(arg2) == "computer" then
+		if typeof(arg2) == "shell" then use_comp == arg2.host_computer else use_comp = arg2
+	end if
+
 	if arg1 == "-l" or arg1 == "local" or arg2 == "-l" or arg2 == "local" then dat.push(localip)// ?? #whyemoji.gif
 	if arg1 == "-p" or arg1 == "public" or arg2 == "-p" or arg2 == "public" then dat.push(pubip)// ??
 	if arg1 == "-d" or arg2 == "-d" or arg1 == "devices" or arg2 == "devices" then// ??
@@ -465,7 +469,6 @@ command.ifconfig = function(arg1=0, arg2=0, arg3=0, arg4=0)
 		dat.push(use_comp.network_devices)
 	end if
 
-    // Was it left here by accident? (0.0 )
 	//if typeof(arg1) == "shell" or typeof(arg1) == "computer" then 
 	if arg1 == "-w" or arg1 == "wifi" then 
 		if not arg3 then return "ifconfig: -w expects [essid|bssid] [passykey]"
@@ -933,27 +936,36 @@ command.nsl = function(arg1, arg2, arg3=0, arg4=0)
 	return addy.trim
 end function
 command.ping = function(arg1, arg2=0, arg3=0, arg4=0)
-	if not arg1 or arg1 == "-h" or arg1 == "help" then return command_info("ping_usage")+char(10)+"Note: returns a string."
+	if not arg1 or arg1 == "-h" or arg1 == "help" then return "Usage: ping [ip] [opt:shell] -- send a ping request to the given ip"+char(10)+
+	"-- does not leave a log"+char(10)+
+	"-- returns string with round-trip time"+char(10)+
+	"-- passing a shell object will initiate the ping from the given object"+char(10)+
+	"NOTE: the game does not simulate round-trip time;"+char(10)+
+	"-- round trip time actually measures code-execution time"+char(10)+
+	"-- possibly useful for measuring the game server's latency"
 	if not localmachine.is_network_active then return "ping: no network connection."
 	if not is_valid_ip(arg1) then return command_info("ping_usage")
 	time_s = time
+	hold = globals.shell
+	if typeof(arg2) == "shell" then globals.shell = arg2
 	catch = shell.ping(arg1)
+	globals.shell = hold
 	time_e = ( (time - time_s) * 1000 )
 	if DEBUG then print("catch: "+catch)
 	if catch == true then
 		if typeof(catch) == "string" then
 			return catch
 		else
-			print(colorLightBlue+"Ping "+colorWhite+arg1+"</color>: successful"+CT)
+			print(colorLightBlue+"ping "+colorWhite+arg1+"</color>: successful"+CT)
 			color_time = colorOrange
 			if time_e < .03 then color_time = colorGreen
 			if time_e > .1 then color_time = colorRed
-			return colorLightBlue+"Ping: packet round trip: "+CT+color_time+time_e+CT+colorLightBlue+" ms."+CT
+			return colorLightBlue+"ping: packet round trip: "+CT+color_time+time_e+CT+colorLightBlue+" ms."+CT
 		end if
 	else
 		return colorRed+"ping: "+arg1+" unreachable."
 	end if
-	return 0
+	return null
 end function
 command.whois = function(arg1, arg2, arg3=0, arg4=0)
 	if arg1 == "-h" or arg1 == "help" then return "WHOIS || whois information || network info"+char(10)+
@@ -2360,13 +2372,13 @@ command.meta = function(arg1, arg2, arg3=0, arg4=0)
 				globals.metaLib = arg2
 				print colorLightBlue+"</b><size=75%>meta: loaded new <b>MetaLib</b> object:"
 				ldb = command.linkdb(arg2.lib_name+" v "+arg2.version,"-y")
-				if ldb then print ldb+char(10)+"meta: returning..."
+				if ldb then print ldb+char(10)+"meta: returning..." else return colorRed+"meta: unkown error; please report to Plu70!"
 				return globals.metaLib
 			end if
 			arg = "L"
 			scan_this_lib = arg2
 			ldb = command.linkdb(get_lib(arg,scan_this_lib),"-y") //else return "meta: invalid metaLib"// edit get_lib to take 3rd param: auto link
-			if ldb then print ldb+char(10)+"meta: returning..."
+			print ldb+char(10)+"meta: returning..." 
 			return globals.metaLib
 		end if
 	
@@ -2387,7 +2399,7 @@ command.meta = function(arg1, arg2, arg3=0, arg4=0)
 	
 	end if
 	
-	if not globals.metaxploit then print "meta: metaxploit.so not found" 
+	if not globals.metaxploit then return colorRed+"meta: metaxploit.so not found" 
 	if typeof(globals.metaLib) == "MetaLib" then return globals.metaLib.lib_name + " v " +globals.metaLib.version
 	return "meta: no MetaLib linked"
 	
@@ -2649,7 +2661,9 @@ command.aptm = function(arg1, arg2, arg3=0, arg4=0) // requires aptclient.so
 		case("-d", @apt.del_repo)
 		case("-s", @apt.search)
 		case("--hotswap", @apt.hot_swap)
-	default( @paf )
+	//default( @paf )
+	// experimental
+	if "-u-i-a-d-s--hotswap".indexOf(arg1) != null then return default(@paf) else default(@paf)
 	
 	//apting = true
 	while apting
@@ -2669,7 +2683,7 @@ command.aptm = function(arg1, arg2, arg3=0, arg4=0) // requires aptclient.so
 		print("_____________________________________________")
 		print
 	end while
-	return 0
+	return null
 end function
 command.smtp = function(arg1,arg2=0,arg3=0,arg4=0)
 	if arg1 == "help" or arg1 == "-h" then return "SMTP || MAIL USER LIST"+char(10)+"Usage: smtp [ip] [port] -- return mail user list if ip/port is running smtp mail server"+char(10)+"-- user target ip and target port if not supplied"

--- a/net.5pk.src
+++ b/net.5pk.src
@@ -1,4 +1,4 @@
-if DEBUG then print("<size=75%>loading net.5pk v 4.3.6.1...(153.750)")
+if DEBUG then print("<size=75%>loading net.5pk v 4.3.7...(154.972)")
 
 command.target = function(arg1, arg2, arg3=0, arg4=0)
 	if arg1 == "-h" or arg1 == "help" then return "Target || Target IP || Target Port"+char(10)+"Usage: target -- return current target ip and port"+char(10)+"Usage: target ip -- returns current target ip"+char(10)+"Usage: target pt -- return current target port"+char(10)+"Usage: target [ip] -- set target ip address (ip must be a valid ip)"+char(10)+"Usage: target -p [port] -- set target port (returns target port if not supplied)"+char(10)+"Usage: target [ip] [port] -- set targt ip and port in a single command"+char(10)+char(10)+"Note: target ip and port are used by 5phinx, transmit, meta, db, probe, and others."
@@ -371,13 +371,13 @@ command.scpm = function(arg1, arg2, arg3=0, arg4=0)
 		color_shelle = colorOrange
 		she_buf = []
 		for tb in temp_buf
-            if typeof(tb) == "pshell" then 
+            if typeof(tb) == "pshell" or typeof(tb) == "ftpshell" then 
                 she_buf.push("["+colorWhite+ti+CT+"]"+active_icon+""+color_shelle+"["+checkUser(tb)+":"+typeof(tb)+"]")
                 active_icon = "<b> - </b>"
 			    ti = ti + 1
                 continue
             end if
-			if tb.host_computer.public_ip == globals.shell.host_computer.public_ip and tb.host_computer.local_ip == globals.shell.host_computer.local_ip then active_icon = colorCyan+" * "+CT
+			if p_validate(tb.host_computer,"public_ip") and tb.host_computer.public_ip == globals.shell.host_computer.public_ip and tb.host_computer.local_ip == globals.shell.host_computer.local_ip then active_icon = colorCyan+" * "+CT
 			if ti >= r_index then color_shelle = colorLightBlue
 			she_buf.push("["+colorWhite+ti+CT+"]"+active_icon+""+color_shelle+"["+checkUser(tb)+":"+typeof(tb)+"] "+CT+tb.host_computer.local_ip+" @ <b>"+tb.host_computer.public_ip+"</b>")
 			active_icon = "<b> - </b>"
@@ -446,7 +446,10 @@ command.ifconfig = function(arg1=0, arg2=0, arg3=0, arg4=0)
 			"Usage: ifconfig ["+clb+"-g"+CT+"|gateway] [opt:shell|computer] -- returns the lan ip of the active object's gateway (router)"+char(10)+char(10)+
 			"Usage: ifconfig ["+clb+"-d"+CT+"|devices] [opt:shell|computer] -- list network devices on active computer object"+char(10)+char(10)+
 			colorGreen+"Note: ifconfig> shows localmachine by default"+char(10)+
-			"-- pipe an object to configure a remote machine instead"+char(10)
+			"-- pipe an object to configure a remote machine instead"+char(10)+char(10)+
+			"NOTE: you may reverse the order of arguments:"+char(10)+
+			"--eg: <b>ifconfig -l @B 1</b> is the same as <b>ifconfig @B 1 -l"+char(10)+
+			"--ie:<b> ifconfig [flag] [shell]</b> == <b>ifconfig [shell] [flag]"
 		end if
 	print colorGreen+"- - - - - - - - - - - - - - - - - - - - - - -"
 	dat = []
@@ -3000,7 +3003,8 @@ command.infil = function(sh_ob,par=0,arg2,arg3)
 	"-- untouched npc machines"+char(10)+
 	"-- create a macro that mimics infil's behavior (perms, scpm, perms, run)"+char(10)+
 	"-- to use a different destination folder"
-	if typeof(@sh_ob) != "shell" then return "usage: infil [shell_object]"+char(10)+"-- or:<b> infil -h "
+	//if typeof(@sh_ob) != "shell" and then return "usage: infil [shell_object]"+char(10)+"-- or:<b> infil -h "
+	if not p_validate(@sh_ob,"host_computer") then return "usage: infil [shell|ftpshell]"+char(10)+"-- see:<b> infil -h"
     kit = null
     kit = command.tree("/","rkit","1","N")
     if typeof(kit) != "file" then return cr+"infil: rkit not found; aborting..." else cgo+"infil: found: "+kit.permissions+" "+kit.path


### PR DESCRIPTION
// contrib.5pk: checkUser: added support for ftpComputer and ftpFile type
// 5phinx.5pk: p_validate: will return true when input is null instead of crashing
// malp: fixed crash when buffer contained ftpShell or ftpComputer or ftpFile
// -- removed incompatible buttons from ftpshell handler
// -- fixed get/put buttons in ftshell handler
// -- ftpComputer and ftpFile will be handled by generic object handler (decompiler) in malp
// ---- custom handler when ftpComputer has access to local_ip and public_ip (at least)
// --note: both ftpshell and ftpComputer are extremely limited in functionality
// felix: can work with ftpshell, ftpComputer, ftpFile
// glasspool: will NOT work with ftpshells or computers until kuro adds public and local ip to ftpComputer bc it's bs that they don't have it
// rclean: will now work with ftp objects
// scpm: will now work with ftpshells for both upload and download
// cob: added missing function reference token (@) to _inspectable
// ping: added ability initiate a ping using a piped shell
// -- updated usage info
// code: new option to return the value an individual list index (bc why wasn't that a thing?)
// code: globals.decompiler and globals.p_exe will now take an argument for preselecting a menu option and params
// -- supports invoking methods by name instead of by index #
// ---- argument is passed as FIRST argument and object to decompile is passed as SECOND argument, in this case
// ---- argument should be a string index number or string method name
// ---- use quotes to pass a method/index name along with arguments for the method
// ------eg: if @B 2 is a shell: 
// --------: code @B 2 " ping 1.1.1.1 " 
// --------: code @B 2 " scp /root/rkit /home/guest " // add @clipa, @clipb, @clipc as options
// --------: code @B 2 5 // returns host_computer
// note: these examples are obviously possible wihtout using code, they're just for illustration
// -- code will still return the output of the invoked method	
// aptm: will now return null from the menu and the output of the called function when launched with arguments
// 5phinx.5pk: print override will now use _print internally instead of a recursive call
// ifconfig: pull request: removed incomplete if statement
// ifconfig: will display correct ip info for piped shells/computers
// -- direct consequence is order of arguments no longer matters
// -- usage info updated to reflect this